### PR TITLE
Introduce VideoPlayer UI component

### DIFF
--- a/.snapguidist/__snapshots__/VideoPlayer-1.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-1.snap
@@ -1,0 +1,10 @@
+exports[`VideoPlayer-1 1`] = `
+<video
+  className="AutoUI_VideoPlayer-20"
+  controls={true}
+  poster="">
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-11.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-11.snap
@@ -1,0 +1,11 @@
+exports[`VideoPlayer-11 1`] = `
+<video
+  className="AutoUI_VideoPlayer-20"
+  controls={true}
+  poster=""
+  width={560}>
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-13.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-13.snap
@@ -1,0 +1,7 @@
+exports[`VideoPlayer-13 1`] = `
+<iframe
+  className="AutoUI_VideoPlayer-16"
+  height={315}
+  src="https://www.youtube.com/embed/R6NUFRNEai4?showinfo=0"
+  width={560} />
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-15.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-15.snap
@@ -1,0 +1,7 @@
+exports[`VideoPlayer-15 1`] = `
+<iframe
+  className="AutoUI_VideoPlayer-16"
+  height={315}
+  src="https://www.youtube.com/embed/R6NUFRNEai4?controls=0&showinfo=0"
+  width={560} />
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-17.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-17.snap
@@ -1,0 +1,9 @@
+exports[`VideoPlayer-17 1`] = `
+<video
+  className="AutoUI_VideoPlayer-20"
+  controls={true}
+  poster="">
+  <source />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-3.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-3.snap
@@ -1,0 +1,11 @@
+exports[`VideoPlayer-3 1`] = `
+<video
+  className="AutoUI_VideoPlayer-20"
+  controls={true}
+  poster="http://www.hdfbcover.com/randomcovers/covers/never-stop-dreaming-quote-fb-cover.jpg"
+  width={560}>
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-5.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-5.snap
@@ -1,0 +1,12 @@
+exports[`VideoPlayer-5 1`] = `
+<video
+  className="AutoUI_VideoPlayer-20"
+  controls={false}
+  height={320}
+  poster=""
+  width={560}>
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-6.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-6.snap
@@ -1,0 +1,11 @@
+exports[`VideoPlayer-6 1`] = `
+<video
+  className="video small"
+  controls={true}
+  height={320}
+  poster="">
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-7.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-7.snap
@@ -1,0 +1,12 @@
+exports[`VideoPlayer-7 1`] = `
+<video
+  className="AutoUI_VideoPlayer-20"
+  controls={true}
+  height={320}
+  poster=""
+  width={540}>
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-8.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-8.snap
@@ -1,0 +1,9 @@
+exports[`VideoPlayer-8 1`] = `
+<video
+  className="video small"
+  controls={false}
+  poster="">
+  <source />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-9.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-9.snap
@@ -1,0 +1,11 @@
+exports[`VideoPlayer-9 1`] = `
+<video
+  className="AutoUI_VideoPlayer-20"
+  controls={true}
+  height={320}
+  poster="">
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
+`;

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -1725,7 +1725,7 @@ convert.rgb.gray = function (rgb) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Milestones = exports.RoadmapLevel = exports.RoadmapHero = exports.Text = exports.HorizontalRuler = exports.HeaderBar = exports.XIcon = exports.SvgIcon = exports.PageTitle = exports.ErrorBox = exports.CollapsibleSection = exports.ApplicantListFilter = exports.ApplicantBadge = undefined;
+exports.VideoPlayer = exports.Milestones = exports.RoadmapLevel = exports.RoadmapHero = exports.Text = exports.HorizontalRuler = exports.HeaderBar = exports.XIcon = exports.SvgIcon = exports.PageTitle = exports.ErrorBox = exports.CollapsibleSection = exports.ApplicantListFilter = exports.ApplicantBadge = undefined;
 
 var _ApplicantBadge = __webpack_require__(10);
 
@@ -1779,6 +1779,10 @@ var _Milestones = __webpack_require__(43);
 
 var _Milestones2 = _interopRequireDefault(_Milestones);
 
+var _VideoPlayer = __webpack_require__(44);
+
+var _VideoPlayer2 = _interopRequireDefault(_VideoPlayer);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.ApplicantBadge = _ApplicantBadge2.default;
@@ -1794,6 +1798,7 @@ exports.Text = _Text2.default;
 exports.RoadmapHero = _RoadmapHero2.default;
 exports.RoadmapLevel = _RoadmapLevel2.default;
 exports.Milestones = _Milestones2.default;
+exports.VideoPlayer = _VideoPlayer2.default;
 
 /***/ }),
 /* 10 */
@@ -3974,10 +3979,11 @@ var conversions = __webpack_require__(8);
 	conversions that are not possible simply are not included.
 */
 
+// https://jsperf.com/object-keys-vs-for-in-with-closure/3
+var models = Object.keys(conversions);
+
 function buildGraph() {
 	var graph = {};
-	// https://jsperf.com/object-keys-vs-for-in-with-closure/3
-	var models = Object.keys(conversions);
 
 	for (var len = models.length, i = 0; i < len; i++) {
 		graph[models[i]] = {
@@ -6484,6 +6490,90 @@ Milestones.defaultProps = {
   level: 1
 };
 exports.default = Milestones;
+
+/***/ }),
+/* 44 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = __webpack_require__(0);
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var cmz = __webpack_require__(1);
+
+var iframeStyles = cmz.named('AutoUI_VideoPlayer-16', /*cmz|*/'\n  border: 0;\n' /*|cmz*/);
+
+var videoStyles = cmz.named('AutoUI_VideoPlayer-20', /*cmz|*/'\n  outline: 22px solid #f0f0f0;\n  text-align: center;\n  margin: 0 auto 20px;\n' /*|cmz*/);
+
+var VideoPlayer = function (_PureComponent) {
+  _inherits(VideoPlayer, _PureComponent);
+
+  function VideoPlayer() {
+    _classCallCheck(this, VideoPlayer);
+
+    return _possibleConstructorReturn(this, (VideoPlayer.__proto__ || Object.getPrototypeOf(VideoPlayer)).apply(this, arguments));
+  }
+
+  _createClass(VideoPlayer, [{
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          width = _props.width,
+          height = _props.height,
+          poster = _props.poster,
+          src = _props.src,
+          embedded = _props.embedded,
+          showControls = _props.showControls;
+
+
+      var embeddedVideoSrc = showControls ? src + '?showinfo=0' : src + '?controls=0&showinfo=0';
+
+      return embedded ? _react2.default.createElement('iframe', {
+        className: iframeStyles,
+        width: width,
+        height: height,
+        src: embeddedVideoSrc
+      }) : _react2.default.createElement(
+        'video',
+        {
+          className: videoStyles,
+          controls: showControls,
+          width: width,
+          height: height,
+          poster: poster
+        },
+        _react2.default.createElement('source', { src: src }),
+        'Video cannot be played in this browser.'
+      );
+    }
+  }]);
+
+  return VideoPlayer;
+}(_react.PureComponent);
+
+VideoPlayer.defaultProps = {
+  showControls: true,
+  embedded: false,
+  poster: ''
+};
+exports.default = VideoPlayer;
 
 /***/ })
 /******/ ]);

--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -1,0 +1,69 @@
+// @flow
+
+import React, { PureComponent } from 'react'
+
+const cmz = require('cmz')
+
+type Props = {
+  width?: number,
+  height?: number,
+  poster?: string,
+  embedded?: boolean,
+  showControls?: boolean,
+  src: string,
+}
+
+const iframeStyles = cmz(`
+  border: 0;
+`)
+
+const videoStyles = cmz(`
+  outline: 22px solid #f0f0f0;
+  text-align: center;
+  margin: 0 auto 20px;
+`)
+
+class VideoPlayer extends PureComponent<Props> {
+  static defaultProps = {
+    showControls: true,
+    embedded: false,
+    poster: ''
+  }
+
+  render () {
+    const {
+      width,
+      height,
+      poster,
+      src,
+      embedded,
+      showControls
+    } = this.props
+
+    const embeddedVideoSrc = showControls ? `${src}?showinfo=0` : `${src}?controls=0&showinfo=0`
+
+    return embedded
+      ? (
+        <iframe
+          className={iframeStyles}
+          width={width}
+          height={height}
+          src={embeddedVideoSrc}
+        />
+      )
+      : (
+        <video
+          className={videoStyles}
+          controls={showControls}
+          width={width}
+          height={height}
+          poster={poster}
+        >
+          <source src={src} />
+          Video cannot be played in this browser.
+        </video>
+      )
+  }
+}
+
+export default VideoPlayer

--- a/src/components/VideoPlayer.md
+++ b/src/components/VideoPlayer.md
@@ -1,0 +1,83 @@
+Regular video, source is provided only, video is set to its original sizes:
+
+```js
+<VideoPlayer src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'} />
+```
+
+Poster set:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  width={560}
+  poster={'http://www.hdfbcover.com/randomcovers/covers/never-stop-dreaming-quote-fb-cover.jpg'}
+/>
+```
+
+No controls, custom width and custom height set:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  width={560}
+  height={320}
+  showControls={false}
+/>
+```
+
+Visible controls, custom width and custom height set:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  width={540}
+  height={320}
+/>
+```
+
+Visible controls, custom height set / auto width:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  height={320}
+/>
+```
+
+Visible controls, custom width set / auto height:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  width={560}
+/>
+```
+
+Embedded video, visible controls:
+
+```js
+<VideoPlayer
+  src={'https://www.youtube.com/embed/R6NUFRNEai4'}
+  embedded
+  width={560}
+  height={315}
+/>
+```
+
+Embedded video, hidden controls:
+
+```js
+<VideoPlayer
+  src={'https://www.youtube.com/embed/R6NUFRNEai4'}
+  embedded
+  width={560}
+  height={315}
+  showControls={false}
+/>
+```
+
+Missing props (does component explodes?):
+
+```js
+<VideoPlayer />
+```

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import Text from './components/Text'
 import RoadmapHero from './components/RoadmapHero'
 import RoadmapLevel from './components/RoadmapLevel'
 import Milestones from './components/Milestones'
+import VideoPlayer from './components/VideoPlayer'
 
 export {
   ApplicantBadge,
@@ -25,5 +26,6 @@ export {
   Text,
   RoadmapHero,
   RoadmapLevel,
-  Milestones
+  Milestones,
+  VideoPlayer
 }


### PR DESCRIPTION
Closes #18 

Was a fun one :-) Actually, I made it work with two types of videos:
* embedded videos, like on our `CEOMessage` page, using `embedded` boolean prop
    Can be customised with `width`, `height` and whether to show controls (`showControls`)
* regular video files links, default state
   Can be customised with `width`, `height`, whether to show controls (`showControls`), and a `poster` to preload in place of video

### Spec page

![localhost_6060](https://user-images.githubusercontent.com/579331/32913818-8f85c7d6-cb24-11e7-8e58-ff679f41d1ca.png)

Now we can substitute all the usage of video controls in `Auto` with this component.