### PR TITLE
Prevent firing default onClick event when custom function is provided

### DIFF
--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -6607,8 +6607,7 @@ var Milestones = function (_PureComponent) {
       return stateMap[state];
     }, _this.handleChangeMilestone = function (level, newLevel) {
       return function () {
-        _this.setState({ currentLevel: newLevel });
-        if (typeof level.handleClick === 'function') level.handleClick();
+        if (typeof level.handleClick === 'function') level.handleClick();else _this.setState({ currentLevel: newLevel });
       };
     }, _this.renderMilestone = function (level, index) {
       var currentState = _this.getCurrentState(index);

--- a/src/components/Milestones.js
+++ b/src/components/Milestones.js
@@ -175,8 +175,8 @@ class Milestones extends PureComponent<Props, State> {
   }
 
   handleChangeMilestone = (level: Level, newLevel: number) => () => {
-    this.setState({ currentLevel: newLevel })
     if (typeof level.handleClick === 'function') level.handleClick()
+    else this.setState({ currentLevel: newLevel })
   }
 
   renderMilestone = (level: Level, index: number) => {


### PR DESCRIPTION
Related to: https://github.com/x-team/auto/pull/658#issuecomment-347052788

"milestone nav shouldn't be clickable"

Now, `handleClick` function overrides default action instead of extending it.