### PR TITLE
Handle missing name-related props

### DIFF
--- a/.snapguidist/__snapshots__/ApplicantBadge-5.snap
+++ b/.snapguidist/__snapshots__/ApplicantBadge-5.snap
@@ -1,0 +1,17 @@
+exports[`ApplicantBadge-5 1`] = `
+<div
+  className="AutoUI_ApplicantBadge-6">
+  <img
+    alt=" Lastname\'s avatar"
+    src="https://www.gravatar.com/avatar/0e618c4e06e5fba781c75a9a1b51c1d3?s=64" />
+  <div
+    className="AutoUI_ApplicantBadge-13">
+    <div>
+       Lastname
+    </div>
+    <div>
+      applicant@x-team.com
+    </div>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/ApplicantBadge-7.snap
+++ b/.snapguidist/__snapshots__/ApplicantBadge-7.snap
@@ -1,0 +1,17 @@
+exports[`ApplicantBadge-7 1`] = `
+<div
+  className="AutoUI_ApplicantBadge-6">
+  <img
+    alt="Firstname \'s avatar"
+    src="https://www.gravatar.com/avatar/0e618c4e06e5fba781c75a9a1b51c1d3?s=64" />
+  <div
+    className="AutoUI_ApplicantBadge-13">
+    <div>
+      Firstname 
+    </div>
+    <div>
+      applicant@x-team.com
+    </div>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/ApplicantBadge-9.snap
+++ b/.snapguidist/__snapshots__/ApplicantBadge-9.snap
@@ -2,7 +2,7 @@ exports[`ApplicantBadge-9 1`] = `
 <div
   className="AutoUI_ApplicantBadge-6">
   <img
-    alt=" \'s avatar"
+    alt="avatar"
     src="https://www.gravatar.com/avatar/61a58e425da620d1f4839c6af03ce70f?s=64" />
   <div
     className="AutoUI_ApplicantBadge-13">

--- a/.snapguidist/__snapshots__/ApplicantBadge-9.snap
+++ b/.snapguidist/__snapshots__/ApplicantBadge-9.snap
@@ -1,0 +1,15 @@
+exports[`ApplicantBadge-9 1`] = `
+<div
+  className="AutoUI_ApplicantBadge-6">
+  <img
+    alt=" \'s avatar"
+    src="https://www.gravatar.com/avatar/61a58e425da620d1f4839c6af03ce70f?s=64" />
+  <div
+    className="AutoUI_ApplicantBadge-13">
+    
+    <div>
+      sionlyngle-email@x-team.com
+    </div>
+  </div>
+</div>
+`;

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -2043,12 +2043,13 @@ var ApplicantBadge = function (_PureComponent) {
 
       var shouldRenderName = firstName || lastName;
       var fullName = firstName + ' ' + lastName;
+      var avatarCaption = shouldRenderName ? fullName + '\'s avatar' : 'avatar';
 
       return _react2.default.createElement(
         'div',
         { className: containerStyles },
         _react2.default.createElement('img', {
-          alt: firstName + ' ' + lastName + '\'s avatar',
+          alt: avatarCaption,
           src: 'https://www.gravatar.com/avatar/' + (0, _md2.default)(email) + '?s=64'
         }),
         _react2.default.createElement(

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -2041,6 +2041,9 @@ var ApplicantBadge = function (_PureComponent) {
           lastName = _props.lastName;
 
 
+      var shouldRenderName = firstName || lastName;
+      var fullName = firstName + ' ' + lastName;
+
       return _react2.default.createElement(
         'div',
         { className: containerStyles },
@@ -2051,15 +2054,15 @@ var ApplicantBadge = function (_PureComponent) {
         _react2.default.createElement(
           'div',
           { className: applicantsContainer },
-          _react2.default.createElement(
+          shouldRenderName && _react2.default.createElement(
             'div',
             null,
-            firstName + ' ' + lastName
+            fullName
           ),
           _react2.default.createElement(
             'div',
             null,
-            '' + email
+            email
           ),
           children
         )
@@ -2071,6 +2074,10 @@ var ApplicantBadge = function (_PureComponent) {
 }(_react.PureComponent);
 
 exports.default = ApplicantBadge;
+ApplicantBadge.defaultProps = {
+  firstName: '',
+  lastName: ''
+};
 
 /***/ }),
 /* 13 */

--- a/src/components/ApplicantBadge.js
+++ b/src/components/ApplicantBadge.js
@@ -36,11 +36,12 @@ export default class ApplicantBadge extends PureComponent<Props> {
 
     const shouldRenderName = firstName || lastName
     const fullName = `${firstName} ${lastName}`
+    const avatarCaption = shouldRenderName ? `${fullName}'s avatar`: 'avatar'
 
     return (
       <div className={containerStyles}>
         <img
-          alt={`${firstName} ${lastName}'s avatar`}
+          alt={avatarCaption}
           src={`https://www.gravatar.com/avatar/${md5(email)}?s=64`}
         />
         <div className={applicantsContainer}>

--- a/src/components/ApplicantBadge.js
+++ b/src/components/ApplicantBadge.js
@@ -36,7 +36,7 @@ export default class ApplicantBadge extends PureComponent<Props> {
 
     const shouldRenderName = firstName || lastName
     const fullName = `${firstName} ${lastName}`
-    const avatarCaption = shouldRenderName ? `${fullName}'s avatar`: 'avatar'
+    const avatarCaption = shouldRenderName ? `${fullName}'s avatar` : 'avatar'
 
     return (
       <div className={containerStyles}>

--- a/src/components/ApplicantBadge.js
+++ b/src/components/ApplicantBadge.js
@@ -21,6 +21,11 @@ type Props = {
 }
 
 export default class ApplicantBadge extends PureComponent<Props> {
+  static defaultProps = {
+    firstName: '',
+    lastName: ''
+  }
+
   render () {
     const {
       children,
@@ -29,6 +34,9 @@ export default class ApplicantBadge extends PureComponent<Props> {
       lastName
     } = this.props
 
+    const shouldRenderName = firstName || lastName
+    const fullName = `${firstName} ${lastName}`
+
     return (
       <div className={containerStyles}>
         <img
@@ -36,8 +44,8 @@ export default class ApplicantBadge extends PureComponent<Props> {
           src={`https://www.gravatar.com/avatar/${md5(email)}?s=64`}
         />
         <div className={applicantsContainer}>
-          <div>{`${firstName} ${lastName}`}</div>
-          <div>{`${email}`}</div>
+          {shouldRenderName && <div>{fullName}</div>}
+          <div>{email}</div>
           {children}
         </div>
       </div>

--- a/src/components/ApplicantBadge.md
+++ b/src/components/ApplicantBadge.md
@@ -1,5 +1,4 @@
-
-ApplicantBadge example:
+Basic usage:
 
 ```js
 <ApplicantBadge
@@ -9,7 +8,7 @@ ApplicantBadge example:
 />
 ```
 
-ApplicantBadge with children:
+With children:
 
 ```js
 <ApplicantBadge
@@ -19,4 +18,28 @@ ApplicantBadge with children:
 >
   <button>Hire</button>
 </ApplicantBadge>
+```
+
+No first name provided:
+
+```js
+<ApplicantBadge
+  lastName={'Lastname'}
+  email={'applicant@x-team.com'}
+/>
+```
+
+No last name provided:
+
+```js
+<ApplicantBadge
+  firstName={'Firstname'}
+  email={'applicant@x-team.com'}
+/>
+```
+
+No first name / last name provided:
+
+```js
+<ApplicantBadge email={'sionlyngle-email@x-team.com'} />
 ```


### PR DESCRIPTION
Fixes https://github.com/x-team/auto/issues/654

**Type of Release:** Fix

* Provide defaults for missing props
* Only render name row if any of first name / last name is provided
* Extend spec page with more cases to prove it works in different scenarios:
    * missing `firstName`
    * missing `lastName`
   * missed both props
* Handle avatar's alt text properly

### Spec page

![localhost_6060_](https://user-images.githubusercontent.com/579331/33269608-5acbd60e-d392-11e7-8aef-28c877c63bcd.png)
