### PR TITLE
Add error state for solution form

### DIFF
--- a/.snapguidist/__snapshots__/SolutionForm-1.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-1.snap
@@ -19,7 +19,7 @@ exports[`SolutionForm-1 1`] = `
       name="solution"
       placeholder="Solution" />
     <button
-      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-65"
+      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-75"
       disabled={true}>
       Submit (0 of 3 attempts)
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-3.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-3.snap
@@ -19,7 +19,7 @@ exports[`SolutionForm-3 1`] = `
       name="solution"
       placeholder="Solution" />
     <button
-      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-65"
+      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-75"
       disabled={false}>
       Submit (0 of 5 attempts)
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-5.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-5.snap
@@ -15,11 +15,11 @@ exports[`SolutionForm-5 1`] = `
   <form
     className="AutoUI_SolutionForm_index-25 AutoUI_SolutionForm_index-41">
     <textarea
-      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-49"
+      className="AutoUI_SolutionForm_index-49 AutoUI_SolutionForm_index-62"
       name="solution"
       placeholder="Solution" />
     <button
-      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-65"
+      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-75"
       disabled={false}>
       Submit (2 of 3 attempts)
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-7.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-7.snap
@@ -19,7 +19,7 @@ exports[`SolutionForm-7 1`] = `
       name="solution"
       placeholder="Solution" />
     <button
-      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-65"
+      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-75"
       disabled={true}>
       Checking...
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-9.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-9.snap
@@ -19,7 +19,7 @@ exports[`SolutionForm-9 1`] = `
       name="solution"
       placeholder="Solution" />
     <button
-      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-65"
+      className="AutoUI_SolutionForm_index-26 AutoUI_SolutionForm_index-27 AutoUI_SolutionForm_index-75"
       disabled={false}>
       Submit (0 of 3 attempts)
     </button>

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -203,12 +203,12 @@ var palette = {
   tuna: '#34323B',
   scarpaFlow: '#5A5665',
   manatee: '#918CA0',
-  athensCray: '#F0F1F4',
-  athensCrayAlt: '#E6E6ED',
+  athensGray: '#F0F1F4',
+  athensGrayAlt: '#E6E6ED',
   mercury: '#E4E4E4',
   porcelain: '#E9EDEE',
-  errorRed: '#D32F3B',
-  shadowRed: '#F7D9DC'
+  brickRed: '#D32F3B',
+  wePeep: '#F7D9DC'
 };
 
 exports.default = wrap({
@@ -226,9 +226,9 @@ exports.default = wrap({
 
   formPlaceholder: palette.alto,
   formText: palette.manatee,
-  formBorder: palette.athensCrayAlt,
-  formError: palette.errorRed,
-  formErrorShadow: palette.shadowRed,
+  formBorder: palette.athensGrayAlt,
+  formError: palette.brickRed,
+  formErrorShadow: palette.wePeep,
 
   lineRed: palette.radicalRed,
   // roadmap timeline circle
@@ -237,10 +237,10 @@ exports.default = wrap({
   // milestones circle and line
   lineSilver2: palette.porcelain,
   // roadmap timeline line
-  lineSilver3: palette.athensCray,
+  lineSilver3: palette.athensGray,
   // horizontal ruler
   // collapsible section dividers
-  lineSilver4: palette.athensCrayAlt,
+  lineSilver4: palette.athensGrayAlt,
 
   iconRed: palette.radicalRed,
   iconBright: palette.white,
@@ -7479,12 +7479,12 @@ var Root = _elem2.default.div([utilStyles.maxWidth, cmz.named('AutoUI_SolutionFo
 
 var Form = _elem2.default.form([utilStyles.maxWidth, cmz.named('AutoUI_SolutionForm_index-41', /*cmz|*/'\n    margin: 30px auto\n    position: relative\n  ' /*|cmz*/)]);
 
-var textAreaStyles = [utilStyles.noOutline, cmz.named('AutoUI_SolutionForm_index-49', '\n    display: block\n    width: 100%\n    height: 156px\n    resize: none\n    border: ' + _theme2.default.baseSilver + ' solid 3px\n    border-radius: 4px\n    font-size: 28px\n    padding: 10px 20px\n    box-sizing: border-box\n  ')];
+var textareaStyles = [utilStyles.noOutline, cmz.named('AutoUI_SolutionForm_index-49', '\n    display: block\n    width: 100%\n    height: 156px\n    resize: none\n    border: ' + _theme2.default.baseSilver + ' solid 3px\n    border-radius: 4px\n    font-size: 28px\n    padding: 10px 20px\n    box-sizing: border-box\n  ')];
 
 var errorTextarea = cmz.named('AutoUI_SolutionForm_index-62', '\n  background: ' + _theme2.default.formErrorShadow + '\n  border-color: ' + _theme2.default.formError + '\n  color: ' + _theme2.default.formError + '\n');
 
-var Textarea = _elem2.default.textarea(textAreaStyles);
-var textAreaError = textAreaStyles[1] + (' ' + errorTextarea);
+var Textarea = _elem2.default.textarea(textareaStyles);
+var textAreaError = textareaStyles[1] + (' ' + errorTextarea);
 var ErrorTextarea = _elem2.default.textarea(textAreaError);
 
 var Button = _elem2.default.button([utilStyles.noOutline, utilStyles.noTextDecoration, cmz.named('AutoUI_SolutionForm_index-75', '\n    & {\n      text-transform: uppercase\n      background: ' + _theme2.default.baseRed + '\n      border: transparent solid 2px\n      border-radius: 3px\n      color: ' + _theme2.default.baseBrighter + '\n      cursor: pointer\n      font-size: 1rem\n      margin: 0.25em\n      min-width: 290px\n      padding: .75em 2.4em\n      transition: all .3s ease-out\n      font-weight: 700\n    }\n    &:hover {\n      background: ' + _theme2.default.baseRed + '\n      border-color: transparent\n    }\n    &:active {\n      background: ' + _theme2.default.baseRed + '\n      transition: none\n    }\n    &[disabled] {\n      background-color: ' + _theme2.default.baseSilver + '\n      pointer-events: none\n    }\n  ')]);
@@ -7507,13 +7507,14 @@ var SolutionForm = function (_PureComponent) {
           isSubmitting = _props.isSubmitting,
           maxAttempts = _props.maxAttempts,
           takenAttempts = _props.takenAttempts,
-          onSubmit = _props.onSubmit;
+          onSubmit = _props.onSubmit,
+          onValueChange = _props.onValueChange;
 
 
-      var TextareaToRender = hasAttempted ? ErrorTextarea : Textarea;
+      var TextareaComponent = hasAttempted ? ErrorTextarea : Textarea;
 
-      return Root(_react2.default.createElement(_Title2.default, { hasAttempted: hasAttempted, maxAttempts: maxAttempts }), Form({ onSubmit: onSubmit }, TextareaToRender({
-        onChange: this.props.onValueChange,
+      return Root(_react2.default.createElement(_Title2.default, { hasAttempted: hasAttempted, maxAttempts: maxAttempts }), Form({ onSubmit: onSubmit }, TextareaComponent({
+        onChange: onValueChange,
         placeholder: 'Solution',
         name: 'solution'
       }), Button(isSubmitting ? {

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -206,7 +206,9 @@ var palette = {
   athensCray: '#F0F1F4',
   athensCrayAlt: '#E6E6ED',
   mercury: '#E4E4E4',
-  porcelain: '#E9EDEE'
+  porcelain: '#E9EDEE',
+  errorRed: '#D32F3B',
+  shadowRed: '#F7D9DC'
 };
 
 exports.default = wrap({
@@ -225,6 +227,8 @@ exports.default = wrap({
   formPlaceholder: palette.alto,
   formText: palette.manatee,
   formBorder: palette.athensCrayAlt,
+  formError: palette.errorRed,
+  formErrorShadow: palette.shadowRed,
 
   lineRed: palette.radicalRed,
   // roadmap timeline circle
@@ -7475,9 +7479,15 @@ var Root = _elem2.default.div([utilStyles.maxWidth, cmz.named('AutoUI_SolutionFo
 
 var Form = _elem2.default.form([utilStyles.maxWidth, cmz.named('AutoUI_SolutionForm_index-41', /*cmz|*/'\n    margin: 30px auto\n    position: relative\n  ' /*|cmz*/)]);
 
-var Textarea = _elem2.default.textarea([utilStyles.noOutline, cmz.named('AutoUI_SolutionForm_index-49', '\n    display: block\n    width: 100%\n    height: 156px\n    resize: none\n    border: ' + _theme2.default.baseSilver + ' solid 3px\n    border-radius: 4px\n    font-size: 28px\n    padding: 10px 20px\n    box-sizing: border-box\n  ')]);
+var textAreaStyles = [utilStyles.noOutline, cmz.named('AutoUI_SolutionForm_index-49', '\n    display: block\n    width: 100%\n    height: 156px\n    resize: none\n    border: ' + _theme2.default.baseSilver + ' solid 3px\n    border-radius: 4px\n    font-size: 28px\n    padding: 10px 20px\n    box-sizing: border-box\n  ')];
 
-var Button = _elem2.default.button([utilStyles.noOutline, utilStyles.noTextDecoration, cmz.named('AutoUI_SolutionForm_index-65', '\n    & {\n      text-transform: uppercase\n      background: ' + _theme2.default.baseRed + '\n      border: transparent solid 2px\n      border-radius: 3px\n      color: ' + _theme2.default.baseBrighter + '\n      cursor: pointer\n      font-size: 1rem\n      margin: 0.25em\n      min-width: 290px\n      padding: .75em 2.4em\n      transition: all .3s ease-out\n      font-weight: 700\n    }\n    &:hover {\n      background: ' + _theme2.default.baseRed + '\n      border-color: transparent\n    }\n    &:active {\n      background: ' + _theme2.default.baseRed + '\n      transition: none\n    }\n    &[disabled] {\n      background-color: ' + _theme2.default.baseSilver + '\n      pointer-events: none\n    }\n  ')]);
+var errorTextarea = cmz.named('AutoUI_SolutionForm_index-62', '\n  background: ' + _theme2.default.formErrorShadow + '\n  border-color: ' + _theme2.default.formError + '\n  color: ' + _theme2.default.formError + '\n');
+
+var Textarea = _elem2.default.textarea(textAreaStyles);
+var textAreaError = textAreaStyles[1] + (' ' + errorTextarea);
+var ErrorTextarea = _elem2.default.textarea(textAreaError);
+
+var Button = _elem2.default.button([utilStyles.noOutline, utilStyles.noTextDecoration, cmz.named('AutoUI_SolutionForm_index-75', '\n    & {\n      text-transform: uppercase\n      background: ' + _theme2.default.baseRed + '\n      border: transparent solid 2px\n      border-radius: 3px\n      color: ' + _theme2.default.baseBrighter + '\n      cursor: pointer\n      font-size: 1rem\n      margin: 0.25em\n      min-width: 290px\n      padding: .75em 2.4em\n      transition: all .3s ease-out\n      font-weight: 700\n    }\n    &:hover {\n      background: ' + _theme2.default.baseRed + '\n      border-color: transparent\n    }\n    &:active {\n      background: ' + _theme2.default.baseRed + '\n      transition: none\n    }\n    &[disabled] {\n      background-color: ' + _theme2.default.baseSilver + '\n      pointer-events: none\n    }\n  ')]);
 
 var SolutionForm = function (_PureComponent) {
   _inherits(SolutionForm, _PureComponent);
@@ -7500,7 +7510,9 @@ var SolutionForm = function (_PureComponent) {
           onSubmit = _props.onSubmit;
 
 
-      return Root(_react2.default.createElement(_Title2.default, { hasAttempted: hasAttempted, maxAttempts: maxAttempts }), Form({ onSubmit: onSubmit }, Textarea({
+      var TextareaToRender = hasAttempted ? ErrorTextarea : Textarea;
+
+      return Root(_react2.default.createElement(_Title2.default, { hasAttempted: hasAttempted, maxAttempts: maxAttempts }), Form({ onSubmit: onSubmit }, TextareaToRender({
         onChange: this.props.onValueChange,
         placeholder: 'Solution',
         name: 'solution'

--- a/src/components/SolutionForm/index.js
+++ b/src/components/SolutionForm/index.js
@@ -44,7 +44,7 @@ const Form = elem.form([
   `)
 ])
 
-const Textarea = elem.textarea([
+const textAreaStyles = [
   utilStyles.noOutline,
   cmz(`
     display: block
@@ -57,7 +57,17 @@ const Textarea = elem.textarea([
     padding: 10px 20px
     box-sizing: border-box
   `)
-])
+]
+
+const errorTextarea = cmz(`
+  background: ${theme.formErrorShadow}
+  border-color: ${theme.formError}
+  color: ${theme.formError}
+`)
+
+const Textarea = elem.textarea(textAreaStyles)
+const textAreaError = textAreaStyles[1] + ` ${errorTextarea}`
+const ErrorTextarea = elem.textarea(textAreaError)
 
 const Button = elem.button([
   utilStyles.noOutline,
@@ -111,11 +121,13 @@ export default class SolutionForm extends PureComponent<Props> {
       onSubmit
     } = this.props
 
+    const TextareaToRender = hasAttempted ? ErrorTextarea : Textarea
+
     return Root(
       <Title {... { hasAttempted, maxAttempts }} />,
       Form(
         {onSubmit},
-        Textarea({
+        TextareaToRender({
           onChange: this.props.onValueChange,
           placeholder: 'Solution',
           name: 'solution'

--- a/src/components/SolutionForm/index.js
+++ b/src/components/SolutionForm/index.js
@@ -44,7 +44,7 @@ const Form = elem.form([
   `)
 ])
 
-const textAreaStyles = [
+const textareaStyles = [
   utilStyles.noOutline,
   cmz(`
     display: block
@@ -65,8 +65,8 @@ const errorTextarea = cmz(`
   color: ${theme.formError}
 `)
 
-const Textarea = elem.textarea(textAreaStyles)
-const textAreaError = textAreaStyles[1] + ` ${errorTextarea}`
+const Textarea = elem.textarea(textareaStyles)
+const textAreaError = textareaStyles[1] + ` ${errorTextarea}`
 const ErrorTextarea = elem.textarea(textAreaError)
 
 const Button = elem.button([
@@ -118,17 +118,18 @@ export default class SolutionForm extends PureComponent<Props> {
       isSubmitting,
       maxAttempts,
       takenAttempts,
-      onSubmit
+      onSubmit,
+      onValueChange
     } = this.props
 
-    const TextareaToRender = hasAttempted ? ErrorTextarea : Textarea
+    const TextareaComponent = hasAttempted ? ErrorTextarea : Textarea
 
     return Root(
       <Title {... { hasAttempted, maxAttempts }} />,
       Form(
         {onSubmit},
-        TextareaToRender({
-          onChange: this.props.onValueChange,
+        TextareaComponent({
+          onChange: onValueChange,
           placeholder: 'Solution',
           name: 'solution'
         }),

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -27,12 +27,12 @@ const palette = {
   tuna: '#34323B',
   scarpaFlow: '#5A5665',
   manatee: '#918CA0',
-  athensCray: '#F0F1F4',
-  athensCrayAlt: '#E6E6ED',
+  athensGray: '#F0F1F4',
+  athensGrayAlt: '#E6E6ED',
   mercury: '#E4E4E4',
   porcelain: '#E9EDEE',
-  errorRed: '#D32F3B',
-  shadowRed: '#F7D9DC'
+  brickRed: '#D32F3B',
+  wePeep: '#F7D9DC'
 }
 
 export default wrap({
@@ -50,9 +50,9 @@ export default wrap({
 
   formPlaceholder: palette.alto,
   formText: palette.manatee,
-  formBorder: palette.athensCrayAlt,
-  formError: palette.errorRed,
-  formErrorShadow: palette.shadowRed,
+  formBorder: palette.athensGrayAlt,
+  formError: palette.brickRed,
+  formErrorShadow: palette.wePeep,
 
   lineRed: palette.radicalRed,
   // roadmap timeline circle
@@ -61,10 +61,10 @@ export default wrap({
   // milestones circle and line
   lineSilver2: palette.porcelain,
   // roadmap timeline line
-  lineSilver3: palette.athensCray,
+  lineSilver3: palette.athensGray,
   // horizontal ruler
   // collapsible section dividers
-  lineSilver4: palette.athensCrayAlt,
+  lineSilver4: palette.athensGrayAlt,
 
   iconRed: palette.radicalRed,
   iconBright: palette.white,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -30,7 +30,9 @@ const palette = {
   athensCray: '#F0F1F4',
   athensCrayAlt: '#E6E6ED',
   mercury: '#E4E4E4',
-  porcelain: '#E9EDEE'
+  porcelain: '#E9EDEE',
+  errorRed: '#D32F3B',
+  shadowRed: '#F7D9DC'
 }
 
 export default wrap({
@@ -49,6 +51,8 @@ export default wrap({
   formPlaceholder: palette.alto,
   formText: palette.manatee,
   formBorder: palette.athensCrayAlt,
+  formError: palette.errorRed,
+  formErrorShadow: palette.shadowRed,
 
   lineRed: palette.radicalRed,
   // roadmap timeline circle


### PR DESCRIPTION
Closes #79 

## Impact

Paints the texarea in red when an error attempt is passed on `SolutionForm`.

## For the reviewer

I am not very fond of the way I added styles to the textarea, my best approach would've been to add the normal text area styles and do something like `textareaStyles.compose(redborders)`, but compose is deprecated on `cmz`. Any suggestions are appreciated.