### PR TITLE
Include new render options for CollapsibleSection

### DIFF
--- a/.snapguidist/__snapshots__/CollapsibleSection-1.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-1.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-1 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
+  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
   <h1
-    className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-64">
+    className="AutoUI_ui_CollapsibleSection-74">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,9 +42,9 @@ exports[`CollapsibleSection-1 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-78">
+    className="AutoUI_ui_CollapsibleSection-96">
     <div
-      className="AutoUI_ui_CollapsibleSection-98">
+      className="AutoUI_ui_CollapsibleSection-117">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-1.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-1.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-1 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
+  className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
   <h1
-    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+    className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-74">
+    className="AutoUI_ui_CollapsibleSection-69">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,9 +42,9 @@ exports[`CollapsibleSection-1 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-96">
+    className="AutoUI_ui_CollapsibleSection-91">
     <div
-      className="AutoUI_ui_CollapsibleSection-117">
+      className="AutoUI_ui_CollapsibleSection-112">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-11.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-11.snap
@@ -1,1 +1,54 @@
-exports[`CollapsibleSection-11 1`] = `null`;
+exports[`CollapsibleSection-11 1`] = `
+<section
+  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-32 AutoUI_ui_CollapsibleSection-31">
+  <h1
+    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
+    Consectetur suscipit alias velit magni tenetur veritatis sed fuga
+  </h1>
+  <div
+    className="AutoUI_ui_CollapsibleSection-74">
+    <svg
+      height="20px"
+      viewBox="0 0 20 20"
+      width="20px">
+      <g
+        fill="none"
+        fillRule="evenodd"
+        stroke="none"
+        strokeWidth="1">
+        <g
+          fill={
+            Object {
+              "color": Array [
+                246,
+                57,
+                84,
+              ],
+              "model": "rgb",
+              "valpha": 1,
+            }
+          }
+          transform="translate(-1191.000000, -1411.000000)">
+          <g
+            transform="translate(387.000000, 933.000000)">
+            <g
+              transform="translate(0.000000, 470.000000)">
+              <path
+                d="M813,17 L804,17 L804,19 L813,19 L813,28 L815,28 L815,19 L824,19 L824,17 L815,17 L815,8 L813,8 L813,17 Z" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+  <div
+    className="AutoUI_ui_CollapsibleSection-96">
+    <div
+      className="AutoUI_ui_CollapsibleSection-117">
+      <p>
+        This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
+      </p>
+    </div>
+  </div>
+</section>
+`;

--- a/.snapguidist/__snapshots__/CollapsibleSection-11.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-11.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-11 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-32 AutoUI_ui_CollapsibleSection-31">
+  className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31 AutoUI_ui_CollapsibleSection-30">
   <h1
-    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
+    className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-74">
+    className="AutoUI_ui_CollapsibleSection-69">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,9 +42,9 @@ exports[`CollapsibleSection-11 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-96">
+    className="AutoUI_ui_CollapsibleSection-91">
     <div
-      className="AutoUI_ui_CollapsibleSection-117">
+      className="AutoUI_ui_CollapsibleSection-112">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-13.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-13.snap
@@ -1,14 +1,14 @@
 exports[`CollapsibleSection-13 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-32">
+  className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
   <h1
-    className="AutoUI_ui_CollapsibleSection-55 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
+    className="AutoUI_ui_CollapsibleSection-54 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-96">
+    className="AutoUI_ui_CollapsibleSection-91">
     <div
-      className="AutoUI_ui_CollapsibleSection-117">
+      className="AutoUI_ui_CollapsibleSection-112">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-13.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-13.snap
@@ -1,0 +1,18 @@
+exports[`CollapsibleSection-13 1`] = `
+<section
+  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-32">
+  <h1
+    className="AutoUI_ui_CollapsibleSection-55 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
+    Consectetur suscipit alias velit magni tenetur veritatis sed fuga
+  </h1>
+  <div
+    className="AutoUI_ui_CollapsibleSection-96">
+    <div
+      className="AutoUI_ui_CollapsibleSection-117">
+      <p>
+        This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
+      </p>
+    </div>
+  </div>
+</section>
+`;

--- a/.snapguidist/__snapshots__/CollapsibleSection-15.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-15.snap
@@ -1,0 +1,1 @@
+exports[`CollapsibleSection-15 1`] = `null`;

--- a/.snapguidist/__snapshots__/CollapsibleSection-3.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-3.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-3 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
+  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
   <h1
-    className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-64">
+    className="AutoUI_ui_CollapsibleSection-74">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,6 +42,6 @@ exports[`CollapsibleSection-3 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-78" />
+    className="AutoUI_ui_CollapsibleSection-96" />
 </section>
 `;

--- a/.snapguidist/__snapshots__/CollapsibleSection-3.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-3.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-3 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
+  className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
   <h1
-    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+    className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-74">
+    className="AutoUI_ui_CollapsibleSection-69">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,6 +42,6 @@ exports[`CollapsibleSection-3 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-96" />
+    className="AutoUI_ui_CollapsibleSection-91" />
 </section>
 `;

--- a/.snapguidist/__snapshots__/CollapsibleSection-5.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-5.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-5 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30 AutoUI_ui_CollapsibleSection-31">
+  className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-29 AutoUI_ui_CollapsibleSection-30">
   <h1
-    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+    className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-74">
+    className="AutoUI_ui_CollapsibleSection-69">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,9 +42,9 @@ exports[`CollapsibleSection-5 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-96">
+    className="AutoUI_ui_CollapsibleSection-91">
     <div
-      className="AutoUI_ui_CollapsibleSection-117">
+      className="AutoUI_ui_CollapsibleSection-112">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-5.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-5.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-5 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-29 AutoUI_ui_CollapsibleSection-30">
+  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30 AutoUI_ui_CollapsibleSection-31">
   <h1
-    className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-64">
+    className="AutoUI_ui_CollapsibleSection-74">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,9 +42,9 @@ exports[`CollapsibleSection-5 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-78">
+    className="AutoUI_ui_CollapsibleSection-96">
     <div
-      className="AutoUI_ui_CollapsibleSection-98">
+      className="AutoUI_ui_CollapsibleSection-117">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-7.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-7.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-7 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30 AutoUI_ui_CollapsibleSection-31">
+  className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-29 AutoUI_ui_CollapsibleSection-30">
   <h1
-    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+    className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-74">
+    className="AutoUI_ui_CollapsibleSection-69">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,9 +42,9 @@ exports[`CollapsibleSection-7 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-96">
+    className="AutoUI_ui_CollapsibleSection-91">
     <div
-      className="AutoUI_ui_CollapsibleSection-117">
+      className="AutoUI_ui_CollapsibleSection-112">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-7.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-7.snap
@@ -1,12 +1,12 @@
 exports[`CollapsibleSection-7 1`] = `
 <section
-  className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-29 AutoUI_ui_CollapsibleSection-30">
+  className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30 AutoUI_ui_CollapsibleSection-31">
   <h1
-    className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
     Consectetur suscipit alias velit magni tenetur veritatis sed fuga
   </h1>
   <div
-    className="AutoUI_ui_CollapsibleSection-64">
+    className="AutoUI_ui_CollapsibleSection-74">
     <svg
       height="20px"
       viewBox="0 0 20 20"
@@ -42,9 +42,9 @@ exports[`CollapsibleSection-7 1`] = `
     </svg>
   </div>
   <div
-    className="AutoUI_ui_CollapsibleSection-78">
+    className="AutoUI_ui_CollapsibleSection-96">
     <div
-      className="AutoUI_ui_CollapsibleSection-98">
+      className="AutoUI_ui_CollapsibleSection-117">
       <p>
         This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.
       </p>

--- a/.snapguidist/__snapshots__/CollapsibleSection-9.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-9.snap
@@ -1,13 +1,13 @@
 exports[`CollapsibleSection-9 1`] = `
 <div>
   <section
-    className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
     <h1
-      className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-64">
+      className="AutoUI_ui_CollapsibleSection-74">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -43,16 +43,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-78" />
+      className="AutoUI_ui_CollapsibleSection-96" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
     <h1
-      className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-64">
+      className="AutoUI_ui_CollapsibleSection-74">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -88,16 +88,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-78" />
+      className="AutoUI_ui_CollapsibleSection-96" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
     <h1
-      className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-64">
+      className="AutoUI_ui_CollapsibleSection-74">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -133,16 +133,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-78" />
+      className="AutoUI_ui_CollapsibleSection-96" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
     <h1
-      className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-64">
+      className="AutoUI_ui_CollapsibleSection-74">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -178,16 +178,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-78" />
+      className="AutoUI_ui_CollapsibleSection-96" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-33 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
+    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
     <h1
-      className="AutoUI_ui_CollapsibleSection-47 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34 AutoUI_ui_CollapsibleSection-30">
+      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-64">
+      className="AutoUI_ui_CollapsibleSection-74">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -223,7 +223,7 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-78" />
+      className="AutoUI_ui_CollapsibleSection-96" />
   </section>
 </div>
 `;

--- a/.snapguidist/__snapshots__/CollapsibleSection-9.snap
+++ b/.snapguidist/__snapshots__/CollapsibleSection-9.snap
@@ -1,13 +1,13 @@
 exports[`CollapsibleSection-9 1`] = `
 <div>
   <section
-    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
+    className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
     <h1
-      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+      className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-74">
+      className="AutoUI_ui_CollapsibleSection-69">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -43,16 +43,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-96" />
+      className="AutoUI_ui_CollapsibleSection-91" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
+    className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
     <h1
-      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+      className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-74">
+      className="AutoUI_ui_CollapsibleSection-69">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -88,16 +88,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-96" />
+      className="AutoUI_ui_CollapsibleSection-91" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
+    className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
     <h1
-      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+      className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-74">
+      className="AutoUI_ui_CollapsibleSection-69">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -133,16 +133,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-96" />
+      className="AutoUI_ui_CollapsibleSection-91" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
+    className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
     <h1
-      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+      className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-74">
+      className="AutoUI_ui_CollapsibleSection-69">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -178,16 +178,16 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-96" />
+      className="AutoUI_ui_CollapsibleSection-91" />
   </section>
   <section
-    className="AutoUI_ui_CollapsibleSection-35 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-31">
+    className="AutoUI_ui_CollapsibleSection-34 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_CollapsibleSection-30">
     <h1
-      className="AutoUI_ui_CollapsibleSection-55 AutoUI_ui_CollapsibleSection-31 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+      className="AutoUI_ui_CollapsibleSection-54 AutoUI_ui_CollapsibleSection-30 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit?
     </h1>
     <div
-      className="AutoUI_ui_CollapsibleSection-74">
+      className="AutoUI_ui_CollapsibleSection-69">
       <svg
         height="20px"
         viewBox="0 0 20 20"
@@ -223,7 +223,7 @@ exports[`CollapsibleSection-9 1`] = `
       </svg>
     </div>
     <div
-      className="AutoUI_ui_CollapsibleSection-96" />
+      className="AutoUI_ui_CollapsibleSection-91" />
   </section>
 </div>
 `;

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -5061,22 +5061,22 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var cmz = __webpack_require__(1);
 
 var cx = {
-  twoColSection: cmz.named('AutoUI_ui_CollapsibleSection-30', /*cmz|*/'display: flex' /*|cmz*/),
-  clickable: cmz.named('AutoUI_ui_CollapsibleSection-31', /*cmz|*/'cursor: pointer' /*|cmz*/),
-  small: cmz.named('AutoUI_ui_CollapsibleSection-32', /*cmz|*/'display: inline-block' /*|cmz*/)
+  twoColSection: cmz.named('AutoUI_ui_CollapsibleSection-29', /*cmz|*/'display: flex' /*|cmz*/),
+  clickable: cmz.named('AutoUI_ui_CollapsibleSection-30', /*cmz|*/'cursor: pointer' /*|cmz*/),
+  small: cmz.named('AutoUI_ui_CollapsibleSection-31', /*cmz|*/'display: inline-block' /*|cmz*/)
 };
 
-var Root = _elem2.default.section(cmz.named('AutoUI_ui_CollapsibleSection-35', _typo2.default.baseText, '\n  & {\n    margin: 0\n    padding: 32px 16px\n    border-top: 1px solid ' + _theme2.default.lineSilver4 + '\n    position: relative\n  }\n\n  &.' + cx.small + ' {\n    padding: 0\n    border: none\n    flex: 1\n  }\n\n  &:first-child {\n    border-top: 1px solid transparent\n  }\n'));
+var Root = _elem2.default.section(cmz.named('AutoUI_ui_CollapsibleSection-34', _typo2.default.baseText, '\n  & {\n    margin: 0\n    padding: 32px 16px\n    border-top: 1px solid ' + _theme2.default.lineSilver4 + '\n    position: relative\n  }\n\n  &.' + cx.small + ' {\n    padding: 0\n    border: none\n    flex: 1\n  }\n\n  &:first-child {\n    border-top: 1px solid transparent\n  }\n'));
 
-var Header = _elem2.default.h1(cmz.named('AutoUI_ui_CollapsibleSection-55', '\n  & {\n    margin: 0\n    padding-right: 24px\n  }\n\n  .' + cx.twoColSection + ' & {\n    width: 200px\n  }\n\n  .' + cx.small + ' & {\n\n  }\n\n  &:hover {\n    color: ' + _theme2.default.baseDarker + '\n  }\n'));
+var Header = _elem2.default.h1(cmz.named('AutoUI_ui_CollapsibleSection-54', '\n  & {\n    margin: 0\n    padding-right: 24px\n  }\n\n  .' + cx.twoColSection + ' & {\n    width: 200px\n  }\n\n  &:hover {\n    color: ' + _theme2.default.baseDarker + '\n  }\n'));
 
-var IconWrapper = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-74', '\n  & {\n    position: absolute\n    top: 34px\n    right: 10px\n    cursor: pointer\n    width: 12px\n    height: 12px\n    display: block\n  }\n\n  .' + cx.small + ' & {\n    top: 0\n  }\n\n  & > svg {\n    width: 12px\n    height: 12px\n    display: block\n  }\n'));
+var IconWrapper = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-69', '\n  & {\n    position: absolute\n    top: 34px\n    right: 10px\n    cursor: pointer\n    width: 12px\n    height: 12px\n    display: block\n  }\n\n  .' + cx.small + ' & {\n    top: 0\n  }\n\n  & > svg {\n    width: 12px\n    height: 12px\n    display: block\n  }\n'));
 
-var Content = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-96', '\n  .' + cx.twoColSection + ' & {\n    width: calc(100% - 200px)\n  }\n\n  & p {\n    line-height: 36px\n  }\n\n  & > :only-child,\n  & > :nth-child(2) {\n    margin-top: 16px\n  }\n\n  .' + cx.twoColSection + ' & > :only-child,\n  .' + cx.small + ' & > :only-child,\n  .' + cx.clickable + ' & > :only-child {\n    margin-top: 0\n  }\n'));
+var Content = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-91', '\n  .' + cx.twoColSection + ' & {\n    width: calc(100% - 200px)\n  }\n\n  & p {\n    line-height: 36px\n  }\n\n  & > :only-child,\n  & > :nth-child(2) {\n    margin-top: 16px\n  }\n\n  .' + cx.twoColSection + ' & > :only-child,\n  .' + cx.small + ' & > :only-child,\n  .' + cx.clickable + ' & > :only-child {\n    margin-top: 0\n  }\n'));
 
-var Visible = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-117', '\n  & {\n    padding-top: 8px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n\n  & > :last-child {\n    margin-bottom: 0\n  }\n'));
+var Visible = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-112', '\n  & {\n    padding-top: 8px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n\n  & > :last-child {\n    margin-bottom: 0\n  }\n'));
 
-var Children = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-135', '\n  & {\n    padding: 0 80px 0 32px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n'));
+var Children = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-130', '\n  & {\n    padding: 0 80px 0 32px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n'));
 
 var CollapsibleSection = function (_PureComponent) {
   _inherits(CollapsibleSection, _PureComponent);
@@ -5105,21 +5105,21 @@ var CollapsibleSection = function (_PureComponent) {
 
       var IconBlock = children && IconWrapper({
         onClick: function onClick() {
-          return children ? handleToggleCollapse(!isCollapsed) : null;
+          return handleToggleCollapse(!isCollapsed);
         }
       }, _react2.default.createElement(_SvgIcon2.default, { icon: isCollapsed ? 'plus' : 'minus' }));
 
-      return title !== '' ? Root({
+      return title !== '' && Root({
         onClick: function onClick() {
-          return children && isCollapsed ? handleToggleCollapse(false) : null;
+          return children && isCollapsed && handleToggleCollapse(false);
         },
         className: [isTwoColumns && cx.twoColSection, small && cx.small, isCollapsed && children && cx.clickable]
       }, Header({
         onClick: function onClick() {
-          return children ? handleToggleCollapse(!isCollapsed) : null;
+          return children && handleToggleCollapse(!isCollapsed);
         },
         className: [children && cx.clickable, small ? _typo2.default.badgeHeading : _typo2.default.sectionHeading]
-      }, title), IconBlock, ContentBlock) : null;
+      }, title), IconBlock, ContentBlock);
     }
   }]);
 

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -5061,21 +5061,22 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var cmz = __webpack_require__(1);
 
 var cx = {
-  twoColSection: cmz.named('AutoUI_ui_CollapsibleSection-29', /*cmz|*/'display: flex' /*|cmz*/),
-  clickable: cmz.named('AutoUI_ui_CollapsibleSection-30', /*cmz|*/'cursor: pointer' /*|cmz*/)
+  twoColSection: cmz.named('AutoUI_ui_CollapsibleSection-30', /*cmz|*/'display: flex' /*|cmz*/),
+  clickable: cmz.named('AutoUI_ui_CollapsibleSection-31', /*cmz|*/'cursor: pointer' /*|cmz*/),
+  small: cmz.named('AutoUI_ui_CollapsibleSection-32', /*cmz|*/'display: inline-block' /*|cmz*/)
 };
 
-var Root = _elem2.default.section(cmz.named('AutoUI_ui_CollapsibleSection-33', _typo2.default.baseText, '\n  & {\n    margin: 0\n    padding: 32px 16px\n    border-top: 1px solid ' + _theme2.default.lineSilver4 + '\n    position: relative\n  }\n\n  &:first-child {\n    border-top: 1px solid transparent\n  }\n'));
+var Root = _elem2.default.section(cmz.named('AutoUI_ui_CollapsibleSection-35', _typo2.default.baseText, '\n  & {\n    margin: 0\n    padding: 32px 16px\n    border-top: 1px solid ' + _theme2.default.lineSilver4 + '\n    position: relative\n  }\n\n  &.' + cx.small + ' {\n    padding: 0\n    border: none\n    flex: 1\n  }\n\n  &:first-child {\n    border-top: 1px solid transparent\n  }\n'));
 
-var Header = _elem2.default.h1(cmz.named('AutoUI_ui_CollapsibleSection-47', _typo2.default.sectionHeading, cx.clickable, '\n  & {\n    margin: 0\n    padding-right: 24px\n  }\n\n  .' + cx.twoColSection + ' & {\n    width: 200px\n  }\n\n  &:hover {\n    color: ' + _theme2.default.baseDarker + '\n  }\n'));
+var Header = _elem2.default.h1(cmz.named('AutoUI_ui_CollapsibleSection-55', '\n  & {\n    margin: 0\n    padding-right: 24px\n  }\n\n  .' + cx.twoColSection + ' & {\n    width: 200px\n  }\n\n  .' + cx.small + ' & {\n\n  }\n\n  &:hover {\n    color: ' + _theme2.default.baseDarker + '\n  }\n'));
 
-var IconWrapper = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-64', /*cmz|*/'\n  & {\n    position: absolute\n    top: 34px\n    right: 10px\n    cursor: pointer\n  }\n\n  & > svg {\n    width: 12px\n    height: 12px\n  }\n' /*|cmz*/));
+var IconWrapper = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-74', '\n  & {\n    position: absolute\n    top: 34px\n    right: 10px\n    cursor: pointer\n    width: 12px\n    height: 12px\n    display: block\n  }\n\n  .' + cx.small + ' & {\n    top: 0\n  }\n\n  & > svg {\n    width: 12px\n    height: 12px\n    display: block\n  }\n'));
 
-var Content = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-78', '\n  .' + cx.twoColSection + ' & {\n    width: calc(100% - 200px)\n  }\n\n  & p {\n    line-height: 36px\n  }\n\n  & > :only-child,\n  & > :nth-child(2) {\n    margin-top: 16px\n  }\n\n  .' + cx.twoColSection + ' & > :only-child,\n  .' + cx.clickable + ' & > :only-child {\n    margin-top: 0\n  }\n'));
+var Content = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-96', '\n  .' + cx.twoColSection + ' & {\n    width: calc(100% - 200px)\n  }\n\n  & p {\n    line-height: 36px\n  }\n\n  & > :only-child,\n  & > :nth-child(2) {\n    margin-top: 16px\n  }\n\n  .' + cx.twoColSection + ' & > :only-child,\n  .' + cx.small + ' & > :only-child,\n  .' + cx.clickable + ' & > :only-child {\n    margin-top: 0\n  }\n'));
 
-var Visible = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-98', '\n  & {\n    padding-top: 8px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n\n  & > :last-child {\n    margin-bottom: 0\n  }\n'));
+var Visible = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-117', '\n  & {\n    padding-top: 8px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n\n  & > :last-child {\n    margin-bottom: 0\n  }\n'));
 
-var Children = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-116', '\n  & {\n    padding: 0 80px 0 32px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n'));
+var Children = _elem2.default.div(cmz.named('AutoUI_ui_CollapsibleSection-135', '\n  & {\n    padding: 0 80px 0 32px\n  }\n\n  .' + cx.twoColSection + ' & {\n    padding: 0 80px 0 0\n  }\n\n  & > :first-child {\n    margin-top: 0\n  }\n'));
 
 var CollapsibleSection = function (_PureComponent) {
   _inherits(CollapsibleSection, _PureComponent);
@@ -5096,27 +5097,29 @@ var CollapsibleSection = function (_PureComponent) {
           isCollapsed = _props.isCollapsed,
           handleToggleCollapse = _props.handleToggleCollapse,
           visible = _props.visible,
+          small = _props.small,
           children = _props.children;
 
 
       var ContentBlock = (visible || children) && Content(visible && (isCollapsed || !isCollapsed && !toggleVisible) && Visible(visible), !isCollapsed && Children(children));
 
-      var iconName = isCollapsed ? 'plus' : 'minus';
-
-      return title !== '' && children ? Root({
+      var IconBlock = children && IconWrapper({
         onClick: function onClick() {
-          return isCollapsed && handleToggleCollapse(false);
+          return children ? handleToggleCollapse(!isCollapsed) : null;
+        }
+      }, _react2.default.createElement(_SvgIcon2.default, { icon: isCollapsed ? 'plus' : 'minus' }));
+
+      return title !== '' ? Root({
+        onClick: function onClick() {
+          return children && isCollapsed ? handleToggleCollapse(false) : null;
         },
-        className: [isTwoColumns && cx.twoColSection, isCollapsed && cx.clickable]
+        className: [isTwoColumns && cx.twoColSection, small && cx.small, isCollapsed && children && cx.clickable]
       }, Header({
         onClick: function onClick() {
-          return handleToggleCollapse(!isCollapsed);
-        }
-      }, title), IconWrapper({
-        onClick: function onClick() {
-          return handleToggleCollapse(!isCollapsed);
-        }
-      }, _react2.default.createElement(_SvgIcon2.default, { icon: iconName })), ContentBlock) : null;
+          return children ? handleToggleCollapse(!isCollapsed) : null;
+        },
+        className: [children && cx.clickable, small ? _typo2.default.badgeHeading : _typo2.default.sectionHeading]
+      }, title), IconBlock, ContentBlock) : null;
     }
   }]);
 
@@ -5130,6 +5133,7 @@ CollapsibleSection.defaultProps = {
   isCollapsed: true,
   handleToggleCollapse: function handleToggleCollapse() {},
   visible: null,
+  small: false,
   children: null
 };
 exports.default = (0, _recompose.compose)((0, _recompose.withState)('isCollapsed', 'handleToggleCollapse', true), (0, _recompose.onlyUpdateForKeys)(['isCollapsed', 'visible', 'children']))(CollapsibleSection);

--- a/src/components/ui/CollapsibleSection.js
+++ b/src/components/ui/CollapsibleSection.js
@@ -22,12 +22,14 @@ type Props = {
   isCollapsed?: boolean,
   handleToggleCollapse: Function,
   visible?: Element<*>|string,
+  small?: boolean,
   children?: Element<*>|string,
 }
 
 const cx = {
   twoColSection: cmz('display: flex'),
-  clickable: cmz('cursor: pointer')
+  clickable: cmz('cursor: pointer'),
+  small: cmz('display: inline-block')
 }
 
 const Root = elem.section(cmz(
@@ -39,14 +41,18 @@ const Root = elem.section(cmz(
     position: relative
   }
 
+  &.${cx.small} {
+    padding: 0
+    border: none
+    flex: 1
+  }
+
   &:first-child {
     border-top: 1px solid transparent
   }
 `))
 
-const Header = elem.h1(cmz(
-  typo.sectionHeading,
-  cx.clickable, `
+const Header = elem.h1(cmz(`
   & {
     margin: 0
     padding-right: 24px
@@ -54,6 +60,10 @@ const Header = elem.h1(cmz(
 
   .${cx.twoColSection} & {
     width: 200px
+  }
+
+  .${cx.small} & {
+
   }
 
   &:hover {
@@ -67,11 +77,19 @@ const IconWrapper = elem.div(cmz(`
     top: 34px
     right: 10px
     cursor: pointer
+    width: 12px
+    height: 12px
+    display: block
+  }
+
+  .${cx.small} & {
+    top: 0
   }
 
   & > svg {
     width: 12px
     height: 12px
+    display: block
   }
 `))
 
@@ -90,6 +108,7 @@ const Content = elem.div(cmz(`
   }
 
   .${cx.twoColSection} & > :only-child,
+  .${cx.small} & > :only-child,
   .${cx.clickable} & > :only-child {
     margin-top: 0
   }
@@ -135,6 +154,7 @@ class CollapsibleSection extends PureComponent<Props> {
     isCollapsed: true,
     handleToggleCollapse: () => {},
     visible: null,
+    small: false,
     children: null
   }
 
@@ -146,6 +166,7 @@ class CollapsibleSection extends PureComponent<Props> {
       isCollapsed,
       handleToggleCollapse,
       visible,
+      small,
       children
     } = this.props
 
@@ -154,28 +175,33 @@ class CollapsibleSection extends PureComponent<Props> {
       !isCollapsed && Children(children)
     )
 
-    const iconName: Icon = isCollapsed ? 'plus' : 'minus'
-
-    return (title !== '' && children) ? Root(
+    const IconBlock = children && IconWrapper(
       {
-        onClick: () => isCollapsed && handleToggleCollapse(false),
+        onClick: () => children ? handleToggleCollapse(!isCollapsed) : null
+      },
+      <SvgIcon icon={isCollapsed ? 'plus' : 'minus'} />
+    )
+
+    return title !== '' ? Root(
+      {
+        onClick: () => (children && isCollapsed) ? handleToggleCollapse(false) : null,
         className: [
           isTwoColumns && cx.twoColSection,
-          isCollapsed && cx.clickable
+          small && cx.small,
+          isCollapsed && children && cx.clickable
         ]
       },
       Header(
         {
-          onClick: () => handleToggleCollapse(!isCollapsed)
+          onClick: () => children ? handleToggleCollapse(!isCollapsed) : null,
+          className: [
+            children && cx.clickable,
+            small ? typo.badgeHeading : typo.sectionHeading
+          ]
         },
         title
       ),
-      IconWrapper(
-        {
-          onClick: () => handleToggleCollapse(!isCollapsed)
-        },
-        <SvgIcon icon={iconName} />
-      ),
+      IconBlock,
       ContentBlock
     ) : null
   }

--- a/src/components/ui/CollapsibleSection.js
+++ b/src/components/ui/CollapsibleSection.js
@@ -61,10 +61,6 @@ const Header = elem.h1(cmz(`
     width: 200px
   }
 
-  .${cx.small} & {
-
-  }
-
   &:hover {
     color: ${theme.baseDarker}
   }
@@ -176,14 +172,14 @@ class CollapsibleSection extends PureComponent<Props> {
 
     const IconBlock = children && IconWrapper(
       {
-        onClick: () => children ? handleToggleCollapse(!isCollapsed) : null
+        onClick: () => handleToggleCollapse(!isCollapsed)
       },
       <SvgIcon icon={isCollapsed ? 'plus' : 'minus'} />
     )
 
-    return title !== '' ? Root(
+    return title !== '' && Root(
       {
-        onClick: () => (children && isCollapsed) ? handleToggleCollapse(false) : null,
+        onClick: () => (children && isCollapsed) && handleToggleCollapse(false),
         className: [
           isTwoColumns && cx.twoColSection,
           small && cx.small,
@@ -192,7 +188,7 @@ class CollapsibleSection extends PureComponent<Props> {
       },
       Header(
         {
-          onClick: () => children ? handleToggleCollapse(!isCollapsed) : null,
+          onClick: () => children && handleToggleCollapse(!isCollapsed),
           className: [
             children && cx.clickable,
             small ? typo.badgeHeading : typo.sectionHeading
@@ -202,7 +198,7 @@ class CollapsibleSection extends PureComponent<Props> {
       ),
       IconBlock,
       ContentBlock
-    ) : null
+    )
   }
 }
 

--- a/src/components/ui/CollapsibleSection.js
+++ b/src/components/ui/CollapsibleSection.js
@@ -11,7 +11,6 @@ import typo from '../../styles/typo'
 import SvgIcon from './SvgIcon'
 
 import type { Element } from 'react'
-import type { Icon } from './SvgIcon'
 
 const cmz = require('cmz')
 

--- a/src/components/ui/CollapsibleSection.md
+++ b/src/components/ui/CollapsibleSection.md
@@ -80,6 +80,27 @@ Basic with many items:
 </div>
 ```
 
+Small display with content:
+```js
+<CollapsibleSection
+  title="Consectetur suscipit alias velit magni tenetur veritatis sed fuga"
+  visible=<p>This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.</p>
+  small
+>
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat, quae voluptates consectetur suscipit alias velit magni tenetur veritatis sed fuga.</p>
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat, quae voluptates consectetur suscipit alias velit magni tenetur veritatis sed fuga.</p>
+</CollapsibleSection>
+```
+
+Small display without content:
+```js
+<CollapsibleSection
+  title="Consectetur suscipit alias velit magni tenetur veritatis sed fuga"
+  visible=<p>This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.</p>
+  small
+/>
+```
+
 Missing props (does component explode?):
 
 ```


### PR DESCRIPTION
Requirement for https://github.com/x-team/auto/issues/870

This PR includes updates for `<CollapsibleSection />`:

- new prop `small` (boolean, default to false) that renders visually differently, with this prop set to true header is smaller and the section have no paddings;
- empty `children` is optional and will render the component instead null as before, with this change, when children is null, the component will not be clickable and the plus/minus icon will not be displayed;

## Code samples

Small display with content:
```js
<CollapsibleSection
  title="Consectetur suscipit alias velit magni tenetur veritatis sed fuga"
  visible=<p>This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.</p>
  small
>
  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat, quae voluptates consectetur suscipit alias velit magni tenetur veritatis sed fuga.</p>
  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat, quae voluptates consectetur suscipit alias velit magni tenetur veritatis sed fuga.</p>
</CollapsibleSection>
```

Small display without content:
```js
<CollapsibleSection
  title="Consectetur suscipit alias velit magni tenetur veritatis sed fuga"
  visible=<p>This paragraph is always visible. Ipsa recusandae sequi, dicta laboriosam rerum ad ex voluptatibus nostrum fugiat.</p>
  small
/>
```


## Preview
![screen recording 2018-02-05 at 07 27 pm](https://user-images.githubusercontent.com/131859/35829771-1e530c06-0aab-11e8-8a48-638123764cfa.gif)
