### PR TITLE
Improve readability of ErrorBox

### DIFF
--- a/src/components/ui/ErrorBox.js
+++ b/src/components/ui/ErrorBox.js
@@ -20,9 +20,8 @@ const Root = elem.div(cmz(
   color: ${theme.baseRed.darken(0.3)}
   border: 2px solid ${theme.baseRed}
   border-radius: .175em
-  background: ${theme.baseRed.lighten(0.3)}
-  font-style: italic
-  margin: 10px
+  background: ${theme.baseRed.lighten(0.65)}
+  margin: 10px 0
 `))
 
 const List = elem.ul(cmz(`


### PR DESCRIPTION
Fixes #118 

- more text contrast
- removed italic style
- removed left/right margin

Now looks like this:

<img width="668" alt="image" src="https://user-images.githubusercontent.com/36711/36187681-16611f5a-119b-11e8-9714-8811b6a1a530.png">
