### PR TITLE
Make InputField labels inherit display property

### DIFF
--- a/.snapguidist/__snapshots__/InputField-1.snap
+++ b/.snapguidist/__snapshots__/InputField-1.snap
@@ -11,7 +11,7 @@ exports[`InputField-1 1`] = `
     </section>
     <input
       aria-labelledby="label-name"
-      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81"
+      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82"
       defaultValue="Simon"
       id="name"
       name="name"

--- a/.snapguidist/__snapshots__/InputField-11.snap
+++ b/.snapguidist/__snapshots__/InputField-11.snap
@@ -2,7 +2,7 @@ exports[`InputField-11 1`] = `
 <div>
   <input
     aria-labelledby=""
-    className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81"
+    className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82"
     type="text" />
 </div>
 `;

--- a/.snapguidist/__snapshots__/InputField-3.snap
+++ b/.snapguidist/__snapshots__/InputField-3.snap
@@ -11,7 +11,7 @@ exports[`InputField-3 1`] = `
     </section>
     <textarea
       aria-labelledby="label-availability"
-      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81"
+      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82"
       id="availability"
       name="availability"
       placeholder="I am currrently…"

--- a/.snapguidist/__snapshots__/InputField-5.snap
+++ b/.snapguidist/__snapshots__/InputField-5.snap
@@ -1,17 +1,17 @@
 exports[`InputField-5 1`] = `
 <section>
   <div
-    className="AutoUI_forms_InputField-72">
+    className="AutoUI_forms_InputField-73">
     <label
       id="">
       <div
-        className="AutoUI_forms_InputField-72">
+        className="AutoUI_forms_InputField-73">
         <label
           className="AutoUI_forms_InputField-64 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
           <input
             aria-labelledby=""
             checked={false}
-            className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81 AutoUI_forms_InputField-45"
+            className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-45"
             type="radio" />
           <span
             className="AutoUI_forms_InputField-37" />
@@ -21,17 +21,17 @@ exports[`InputField-5 1`] = `
     </label>
   </div>
   <div
-    className="AutoUI_forms_InputField-72">
+    className="AutoUI_forms_InputField-73">
     <label
       id="">
       <div
-        className="AutoUI_forms_InputField-72">
+        className="AutoUI_forms_InputField-73">
         <label
           className="AutoUI_forms_InputField-64 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
           <input
             aria-labelledby=""
             checked={false}
-            className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81 AutoUI_forms_InputField-45"
+            className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-45"
             type="radio" />
           <span
             className="AutoUI_forms_InputField-37" />

--- a/.snapguidist/__snapshots__/InputField-7.snap
+++ b/.snapguidist/__snapshots__/InputField-7.snap
@@ -1,19 +1,19 @@
 exports[`InputField-7 1`] = `
 <div
-  className="AutoUI_forms_InputField-72">
+  className="AutoUI_forms_InputField-73">
   <label
     id="">
     <div
-      className="AutoUI_forms_InputField-72">
+      className="AutoUI_forms_InputField-73">
       <label
         className="AutoUI_forms_InputField-64 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
         <input
           aria-labelledby=""
           checked={true}
-          className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81 AutoUI_forms_InputField-112"
+          className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-113"
           type="checkbox" />
         <span
-          className="AutoUI_forms_InputField-124" />
+          className="AutoUI_forms_InputField-125" />
         Checkbox
       </label>
     </div>

--- a/.snapguidist/__snapshots__/InputField-9.snap
+++ b/.snapguidist/__snapshots__/InputField-9.snap
@@ -11,7 +11,7 @@ exports[`InputField-9 1`] = `
     </section>
     <input
       aria-labelledby="label-invalid"
-      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81 AutoUI_forms_InputField-105"
+      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-106"
       id="invalid"
       name="invalid"
       placeholder="Error Placeholder.."

--- a/.snapguidist/__snapshots__/InputGroup-1.snap
+++ b/.snapguidist/__snapshots__/InputGroup-1.snap
@@ -8,7 +8,7 @@ exports[`InputGroup-1 1`] = `
   <div>
     <input
       aria-labelledby="label-soAccount"
-      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81"
+      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82"
       defaultValue="so_account"
       id="soAccount"
       maxLength={20}

--- a/.snapguidist/__snapshots__/InputGroup-3.snap
+++ b/.snapguidist/__snapshots__/InputGroup-3.snap
@@ -6,7 +6,7 @@ exports[`InputGroup-3 1`] = `
   <div>
     <input
       aria-labelledby=""
-      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-81"
+      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82"
       type="text" />
   </div>
 </div>

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -2160,20 +2160,20 @@ var radioInputStyles = {
   option: cmz.named('AutoUI_forms_InputField-59', /*cmz|*/'\n    margin-left: 50px\n  ' /*|cmz*/)
 };
 
-var labelStyles = cmz.named('AutoUI_forms_InputField-64', _typo2.default.baseText, /*cmz|*/'\n    margin-left: 30px\n  ' /*|cmz*/);
+var labelStyles = cmz.named('AutoUI_forms_InputField-64', _typo2.default.baseText, /*cmz|*/'\n    margin-left: 30px\n    display: inherit\n  ' /*|cmz*/);
 
 var ComponentRoot = _elem2.default.div();
-var FieldRoot = _elem2.default.div(cmz.named('AutoUI_forms_InputField-72', /*cmz|*/'\n  display: inline-block\n  position: relative\n' /*|cmz*/));
+var FieldRoot = _elem2.default.div(cmz.named('AutoUI_forms_InputField-73', /*cmz|*/'\n  display: inline-block\n  position: relative\n' /*|cmz*/));
 var RadioCircle = _elem2.default.span(radioInputStyles.circle);
 var Label = _elem2.default.label(labelStyles);
 
-var inputStyles = [_typo2.default.formText, cmz.named('AutoUI_forms_InputField-81', '\n    & {\n      position: relative\n      display: table-cell\n      margin: 0 !important\n      outline: none\n      width: 100%\n      height: 70px\n      padding: 10px 18px\n      border: 1px solid ' + _theme2.default.formBorder + '\n      box-sizing: border-box\n      z-index: 2\n    }\n\n    &::-webkit-input-placeholder {\n      color: ' + _theme2.default.formPlaceholder + '\n    }\n\n    &::-moz-placeholder {\n      color: ' + _theme2.default.formPlaceholder + '\n    }\n  ')];
+var inputStyles = [_typo2.default.formText, cmz.named('AutoUI_forms_InputField-82', '\n    & {\n      position: relative\n      display: table-cell\n      margin: 0 !important\n      outline: none\n      width: 100%\n      height: 70px\n      padding: 10px 18px\n      border: 1px solid ' + _theme2.default.formBorder + '\n      box-sizing: border-box\n      z-index: 2\n    }\n\n    &::-webkit-input-placeholder {\n      color: ' + _theme2.default.formPlaceholder + '\n    }\n\n    &::-moz-placeholder {\n      color: ' + _theme2.default.formPlaceholder + '\n    }\n  ')];
 
-var errorInput = cmz.named('AutoUI_forms_InputField-105', '\n  background: ' + _theme2.default.formErrorShadow + '\n  border-color: ' + _theme2.default.formError + '\n  color: ' + _theme2.default.formError + '\n');
+var errorInput = cmz.named('AutoUI_forms_InputField-106', '\n  background: ' + _theme2.default.formErrorShadow + '\n  border-color: ' + _theme2.default.formError + '\n  color: ' + _theme2.default.formError + '\n');
 
 var checkboxInputStyles = {
-  input: cmz.named('AutoUI_forms_InputField-112', '\n    & {\n      display: none !important\n    }\n\n    &:checked ~ span {\n      background-color: ' + _theme2.default.baseRed + '\n    }\n    &:checked ~ span:after {\n      opacity: 1\n    }\n  '),
-  tick: cmz.named('AutoUI_forms_InputField-124', '\n    & {\n      position: absolute\n      width: 18px\n      height: 18px\n      top: 6px\n      left: 0\n      border: 1px solid ' + _theme2.default.formBorder + '\n      border-radius: 4px\n    }\n\n    &:after {\n      opacity: 0\n      content: \' \'\n      position: absolute\n      width: 8px\n      height: 4px\n      top: 5px\n      left: 4px\n      border: 2px solid ' + _theme2.default.baseBrighter + '\n      border-top: none\n      border-right: none\n      transform: rotate(-45deg)\n      transition: all 0.25s ease\n    }\n  ')
+  input: cmz.named('AutoUI_forms_InputField-113', '\n    & {\n      display: none !important\n    }\n\n    &:checked ~ span {\n      background-color: ' + _theme2.default.baseRed + '\n    }\n    &:checked ~ span:after {\n      opacity: 1\n    }\n  '),
+  tick: cmz.named('AutoUI_forms_InputField-125', '\n    & {\n      position: absolute\n      width: 18px\n      height: 18px\n      top: 6px\n      left: 0\n      border: 1px solid ' + _theme2.default.formBorder + '\n      border-radius: 4px\n    }\n\n    &:after {\n      opacity: 0\n      content: \' \'\n      position: absolute\n      width: 8px\n      height: 4px\n      top: 5px\n      left: 4px\n      border: 2px solid ' + _theme2.default.baseBrighter + '\n      border-top: none\n      border-right: none\n      transform: rotate(-45deg)\n      transition: all 0.25s ease\n    }\n  ')
 };
 
 var CheckboxTick = _elem2.default.span(checkboxInputStyles.tick);

--- a/src/components/forms/InputField.js
+++ b/src/components/forms/InputField.js
@@ -65,6 +65,7 @@ const labelStyles = cmz(
   typo.baseText,
   `
     margin-left: 30px
+    display: inherit
   `
 )
 


### PR DESCRIPTION
Closes: https://github.com/x-team/auto-ui/issues/123
This is causing availability fields to cut off on mobile in auto: https://github.com/x-team/auto/issues/916

Before:
<img width="439" alt="screen shot 2018-02-21 at 12 29 40 pm" src="https://user-images.githubusercontent.com/1009156/36495621-dac5b3ac-1703-11e8-9f18-35245cf92320.png">

After:
<img width="456" alt="screen shot 2018-02-21 at 12 32 20 pm" src="https://user-images.githubusercontent.com/1009156/36495623-dd3b860c-1703-11e8-8acc-8250e1ac410a.png">
