### PR TITLE
Fix TextArea component focus issue

### DIFF
--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -9053,13 +9053,16 @@ var TextareaEditor = function (_PureComponent) {
     return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TextareaEditor.__proto__ || Object.getPrototypeOf(TextareaEditor)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       text: _this.props.text || '',
       html: _this.props.html || '',
-      shouldShowTextLength: false
+      shouldShowTextLength: false,
+      options: {
+        placeholder: {
+          text: _this.props.placeholder
+        }
+      }
     }, _this.changeShouldShowTextLength = function (val) {
-      setTimeout(function () {
-        return _this.setState(function () {
-          return { shouldShowTextLength: val };
-        });
-      }, 0);
+      _this.setState(function () {
+        return { shouldShowTextLength: val };
+      });
     }, _this.handleChange = function (text, html) {
       _this.setState(function () {
         return { text: text, html: html };
@@ -9101,19 +9104,13 @@ var TextareaEditor = function (_PureComponent) {
     value: function render() {
       var _props = this.props,
           charLimit = _props.charLimit,
-          placeholder = _props.placeholder,
           id = _props.id;
       var _state = this.state,
           text = _state.text,
           html = _state.html,
-          shouldShowTextLength = _state.shouldShowTextLength;
+          shouldShowTextLength = _state.shouldShowTextLength,
+          options = _state.options;
 
-
-      var options = {
-        placeholder: {
-          text: placeholder
-        }
-      };
 
       var counterVisibilityClassName = shouldShowTextLength ? '' : 'hidden';
 

--- a/src/components/ui/TextareaEditor/TextareaEditor.js
+++ b/src/components/ui/TextareaEditor/TextareaEditor.js
@@ -84,7 +84,12 @@ type Props = {
 type State = {
   text: string,
   html: string,
-  shouldShowTextLength: boolean
+  shouldShowTextLength: boolean,
+  options: {
+    placeholder: {
+      text: string
+    }
+  }
 }
 
 class TextareaEditor extends PureComponent<Props, State> {
@@ -95,11 +100,16 @@ class TextareaEditor extends PureComponent<Props, State> {
   state = {
     text: this.props.text || '',
     html: this.props.html || '',
-    shouldShowTextLength: false
+    shouldShowTextLength: false,
+    options: {
+      placeholder: {
+        text: this.props.placeholder
+      }
+    }
   }
 
   changeShouldShowTextLength = (val: boolean) => {
-    setTimeout(() => this.setState(() => ({ shouldShowTextLength: val })), 0)
+    this.setState(() => ({ shouldShowTextLength: val }))
   }
 
   handleChange = (text: string, html: string) => {
@@ -133,14 +143,8 @@ class TextareaEditor extends PureComponent<Props, State> {
   }
 
   render () {
-    const { charLimit, placeholder, id } = this.props
-    const { text, html, shouldShowTextLength } = this.state
-
-    const options = {
-      placeholder: {
-        text: placeholder
-      }
-    }
+    const { charLimit, id } = this.props
+    const { text, html, shouldShowTextLength, options } = this.state
 
     const counterVisibilityClassName = shouldShowTextLength ? '' : 'hidden'
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Provide a general summary of your changes in the Title above. Do not include any task numbers.
Use imperative, present tense: "Change" not "Changed" nor "Changes". This will become a correct final merge commit message 😄
The imperative tells someone what merging the PR **will do**, rather than **what you did**.
-->

**Release Type:** *FIX* <!-- Refer to the wiki https://github.com/x-team/auto/wiki/Release-Process#types-of-releases -->
<!--
Basic types are:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->

Fixes #128

## Description

When changing focus from one text area component to another you had to click twice to make it work.

The issue was that the "onBlur" event triggers a change in the state which re-renders the `TextArea component` and the `MediumEditorWrapper` which triggers a new focus event.

The `MediumEditorWrapper` was unnecessarily rerendered because the `options` prop was a new object created in the render method that caused PureComponent's shouldComponentUpdate shallow validation to fail.

Extracting the options to the state fixed the issue 🙂 

## Checklist

**Before submitting a pull request,** please make sure the following is done:

<!-- Remove items that do not apply. Just tick completed items in UI -->
- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (initially it's mostly `ready for review`)
- [x] set `ready for review` label for respective issue as well
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run typecheck`)
- [x] **manually tested the app** by running it in the browser and checked nothing is broken and operates as expected!
