### PR TITLE
Add toggle switch component

### DIFF
--- a/.snapguidist/__snapshots__/InputField-11.snap
+++ b/.snapguidist/__snapshots__/InputField-11.snap
@@ -1,8 +1,21 @@
 exports[`InputField-11 1`] = `
 <div>
-  <input
-    aria-labelledby=""
-    className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82"
-    type="text" />
+  <label
+    id="label-invalid">
+    <section
+      className="AutoUI_ui_Text-27">
+      <div
+        className="AutoUI_ui_Text-41 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+        Invalid Field
+      </div>
+    </section>
+    <input
+      aria-labelledby="label-invalid"
+      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-106"
+      id="invalid"
+      name="invalid"
+      placeholder="Error Placeholder.."
+      type="text" />
+  </label>
 </div>
 `;

--- a/.snapguidist/__snapshots__/InputField-13.snap
+++ b/.snapguidist/__snapshots__/InputField-13.snap
@@ -1,0 +1,8 @@
+exports[`InputField-13 1`] = `
+<div>
+  <input
+    aria-labelledby=""
+    className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82"
+    type="text" />
+</div>
+`;

--- a/.snapguidist/__snapshots__/InputField-7.snap
+++ b/.snapguidist/__snapshots__/InputField-7.snap
@@ -13,7 +13,7 @@ exports[`InputField-7 1`] = `
           className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-113"
           type="checkbox" />
         <span
-          className="AutoUI_forms_InputField-125" />
+          className="AutoUI_forms_InputField-126" />
         Checkbox
       </label>
     </div>

--- a/.snapguidist/__snapshots__/InputField-9.snap
+++ b/.snapguidist/__snapshots__/InputField-9.snap
@@ -1,21 +1,22 @@
 exports[`InputField-9 1`] = `
-<div>
+<div
+  className="AutoUI_forms_InputField-73">
   <label
-    id="label-invalid">
-    <section
-      className="AutoUI_ui_Text-27">
-      <div
-        className="AutoUI_ui_Text-41 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
-        Invalid Field
-      </div>
-    </section>
-    <input
-      aria-labelledby="label-invalid"
-      className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-106"
-      id="invalid"
-      name="invalid"
-      placeholder="Error Placeholder.."
-      type="text" />
+    id="">
+    <div
+      className="AutoUI_forms_InputField-73">
+      <label
+        className="AutoUI_forms_InputField-64 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+        <input
+          aria-labelledby=""
+          checked={true}
+          className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-156"
+          type="checkbox" />
+        <span
+          className="AutoUI_forms_InputField-171" />
+        Sliding Checkbox
+      </label>
+    </div>
   </label>
 </div>
 `;

--- a/.snapguidist/__snapshots__/InputField-9.snap
+++ b/.snapguidist/__snapshots__/InputField-9.snap
@@ -10,10 +10,10 @@ exports[`InputField-9 1`] = `
         <input
           aria-labelledby=""
           checked={true}
-          className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-156"
+          className="AutoUI_typo-179 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-82 AutoUI_forms_InputField-157"
           type="checkbox" />
         <span
-          className="AutoUI_forms_InputField-171" />
+          className="AutoUI_forms_InputField-172" />
         Sliding Checkbox
       </label>
     </div>

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -214,6 +214,7 @@ exports.default = wrap({
   baseBrighter: palette.white,
   baseDarker: palette.haiti,
   baseRed: palette.radicalRed,
+  baseLightRed: palette.wePeep,
   baseGreen: palette.fern,
   baseSilver: palette.alto,
   baseHighlight: palette.mercury,
@@ -222,6 +223,9 @@ exports.default = wrap({
   typoSubheading: palette.radicalRed,
   typoParagraph: palette.scarpaFlow,
   typoHighlight: palette.haiti,
+
+  sliderToggle: palette.bombay,
+  sliderBackground: palette.athensGray,
 
   formPlaceholder: palette.manatee,
   formText: palette.scarpaFlow,
@@ -2408,17 +2412,35 @@ var errorInput = cmz.named('AutoUI_forms_InputField-106', '\n  background: ' + _
 
 var checkboxInputStyles = {
   input: cmz.named('AutoUI_forms_InputField-113', '\n    & {\n      display: none !important\n    }\n\n    &:checked ~ span {\n      background-color: ' + _theme2.default.baseRed + '\n    }\n    &:checked ~ span:after {\n      opacity: 1\n    }\n  '),
-  tick: cmz.named('AutoUI_forms_InputField-125', '\n    & {\n      position: absolute\n      width: 18px\n      height: 18px\n      top: 6px\n      left: 0\n      border: 1px solid ' + _theme2.default.formBorder + '\n      border-radius: 4px\n    }\n\n    &:after {\n      opacity: 0\n      content: \' \'\n      position: absolute\n      width: 8px\n      height: 4px\n      top: 5px\n      left: 4px\n      border: 2px solid ' + _theme2.default.baseBrighter + '\n      border-top: none\n      border-right: none\n      transform: rotate(-45deg)\n      transition: all 0.25s ease\n    }\n  ')
+
+  tick: cmz.named('AutoUI_forms_InputField-126', '\n    & {\n      position: absolute\n      width: 18px\n      height: 18px\n      top: 6px\n      left: 0\n      border: 1px solid ' + _theme2.default.formBorder + '\n      border-radius: 4px\n    }\n\n    &:after {\n      opacity: 0\n      content: \' \'\n      position: absolute\n      width: 8px\n      height: 4px\n      top: 5px\n      left: 4px\n      border: 2px solid ' + _theme2.default.baseBrighter + '\n      border-top: none\n      border-right: none\n      transform: rotate(-45deg)\n      transition: all 0.25s ease\n    }\n  ')
 };
 
 var CheckboxTick = _elem2.default.span(checkboxInputStyles.tick);
+
+var slidingCheckboxInputStyles = {
+  input: cmz.named('AutoUI_forms_InputField-157', '\n    & {\n      display: none !important\n    }\n\n    &:checked ~ span:before {\n      background-color: ' + _theme2.default.baseLightRed + '\n    }\n\n    &:checked ~ span:after {\n      background-color: ' + _theme2.default.baseRed + '\n      transform: translate(100%, -50%)\n    }\n  '),
+
+  tick: cmz.named('AutoUI_forms_InputField-172', '\n    & {\n      margin-left: 26px\n      cursor: pointer\n    }\n\n    &:before {\n      content: \'\'\n      position: absolute\n      top: 50%\n      left: 0\n      width: 46px\n      height: 12px\n      border-radius: 12px\n      background-color: ' + _theme2.default.sliderBackground + '\n      transform: translateY(-50%)\n      transition: background-color 200ms ease-in-out\n    }\n\n    &:after {\n      content: \'\'\n      position: absolute\n      top: 50%\n      left: 0\n      width: 24px\n      height: 24px\n      border-radius: 50%\n      background-color: ' + _theme2.default.sliderToggle + '\n      transform: translateY(-50%)\n      transition: transform 300ms ease-in-out, background-color 200ms ease-in-out\n    }\n  ')
+};
+
+var SlidingCheckboxTick = _elem2.default.span(slidingCheckboxInputStyles.tick);
 
 var getTagName = function getTagName(type) {
   return type === 'textarea' ? 'textarea' : 'input';
 };
 
+var customTypesDefinitions = {
+  'sliding-checkbox': 'checkbox'
+};
+
+var getFinalType = function getFinalType(type) {
+  return customTypesDefinitions[type] || type;
+};
+
 var inputFactory = function inputFactory(type) {
-  return _elem2.default[getTagName(type)](inputStyles);
+  var finalType = getFinalType(type);
+  return _elem2.default[getTagName(finalType)](inputStyles);
 };
 
 var specialTypesDefinitions = {
@@ -2430,6 +2452,11 @@ var specialTypesDefinitions = {
   checkbox: {
     className: checkboxInputStyles.input,
     ElemBox: CheckboxTick,
+    ElemLabel: Label
+  },
+  'sliding-checkbox': {
+    className: slidingCheckboxInputStyles.input,
+    ElemBox: SlidingCheckboxTick,
     ElemLabel: Label
   }
 };
@@ -2467,6 +2494,7 @@ var InputField = function (_PureComponent) {
       var inputId = id || name;
       var labelId = inputId ? 'label-' + inputId : '';
       var errorClassName = isInvalid ? errorInput : '';
+      var finalType = getFinalType(type);
 
       if (isSpecialType(type)) {
         var _specialTypesDefiniti = specialTypesDefinitions[type],
@@ -2474,13 +2502,14 @@ var InputField = function (_PureComponent) {
             ElemLabel = _specialTypesDefiniti.ElemLabel,
             className = _specialTypesDefiniti.className;
 
+
         return FieldRoot(ElemLabel(Tag(_extends({
           className: className,
-          type: type,
           name: name,
           id: inputId,
           value: value,
           onChange: onChange,
+          type: finalType,
           'aria-labelledby': labelId
         }, rest)), ElemBox(), label));
       }

--- a/src/components/forms/InputField.js
+++ b/src/components/forms/InputField.js
@@ -122,6 +122,7 @@ const checkboxInputStyles = {
       opacity: 1
     }
   `),
+
   tick: cmz(`
     & {
       position: absolute
@@ -156,7 +157,6 @@ const slidingCheckboxInputStyles = {
   input: cmz(`
     & {
       display: none !important
-      width: 46px
     }
 
     &:checked ~ span:before {
@@ -168,33 +168,35 @@ const slidingCheckboxInputStyles = {
       transform: translate(100%, -50%)
     }
   `),
+
   tick: cmz(`
     & {
       margin-left: 26px
+      cursor: pointer
     }
 
     &:before {
       content: ''
+      position: absolute
       top: 50%
       left: 0
-      transform: translateY(-50%)
-      position: absolute
-      height: 12px
       width: 46px
-      background-color: ${theme.sliderBackground}
+      height: 12px
       border-radius: 12px
+      background-color: ${theme.sliderBackground}
+      transform: translateY(-50%)
       transition: background-color 200ms ease-in-out
     }
 
     &:after {
       content: ''
-      background-color: ${theme.sliderToggle}
       position: absolute
-      height: 24px
-      width: 24px
-      border-radius: 100%
-      left: 0
       top: 50%
+      left: 0
+      width: 24px
+      height: 24px
+      border-radius: 50%
+      background-color: ${theme.sliderToggle}
       transform: translateY(-50%)
       transition: transform 300ms ease-in-out, background-color 200ms ease-in-out
     }
@@ -205,21 +207,18 @@ const SlidingCheckboxTick = elem.span(slidingCheckboxInputStyles.tick)
 
 const getTagName = type => type === 'textarea' ? 'textarea' : 'input'
 
-const customTypesDefinitions : Object = {
+const customTypesDefinitions: Object = {
   'sliding-checkbox': 'checkbox'
 }
 
-const getFinalType = type => {
-  const customType = customTypesDefinitions[type]
-  return customType || type
-}
+const getFinalType = type => customTypesDefinitions[type] || type
 
 const inputFactory = type => {
   const finalType = getFinalType(type)
   return elem[getTagName(finalType)](inputStyles)
 }
 
-const specialTypesDefinitions : Object = {
+const specialTypesDefinitions: Object = {
   radio: {
     className: radioInputStyles.input,
     ElemBox: RadioCircle,

--- a/src/components/forms/InputField.js
+++ b/src/components/forms/InputField.js
@@ -152,9 +152,72 @@ const checkboxInputStyles = {
 
 const CheckboxTick = elem.span(checkboxInputStyles.tick)
 
+const slidingCheckboxInputStyles = {
+  input: cmz(`
+    & {
+      display: none !important
+      width: 46px
+    }
+
+    &:checked ~ span:before {
+      background-color: ${theme.baseLightRed}
+    }
+
+    &:checked ~ span:after {
+      background-color: ${theme.baseRed}
+      transform: translate(100%, -50%)
+    }
+  `),
+  tick: cmz(`
+    & {
+      margin-left: 26px
+    }
+
+    &:before {
+      content: ''
+      top: 50%
+      left: 0
+      transform: translateY(-50%)
+      position: absolute
+      height: 12px
+      width: 46px
+      background-color: ${theme.sliderBackground}
+      border-radius: 12px
+      transition: background-color 200ms ease-in-out
+    }
+
+    &:after {
+      content: ''
+      background-color: ${theme.sliderToggle}
+      position: absolute
+      height: 24px
+      width: 24px
+      border-radius: 100%
+      left: 0
+      top: 50%
+      transform: translateY(-50%)
+      transition: transform 300ms ease-in-out, background-color 200ms ease-in-out
+    }
+  `)
+}
+
+const SlidingCheckboxTick = elem.span(slidingCheckboxInputStyles.tick)
+
 const getTagName = type => type === 'textarea' ? 'textarea' : 'input'
 
-const inputFactory = type => elem[getTagName(type)](inputStyles)
+const customTypesDefinitions : Object = {
+  'sliding-checkbox': 'checkbox'
+}
+
+const getFinalType = type => {
+  const customType = customTypesDefinitions[type]
+  return customType || type
+}
+
+const inputFactory = type => {
+  const finalType = getFinalType(type)
+  return elem[getTagName(finalType)](inputStyles)
+}
 
 const specialTypesDefinitions : Object = {
   radio: {
@@ -165,6 +228,11 @@ const specialTypesDefinitions : Object = {
   checkbox: {
     className: checkboxInputStyles.input,
     ElemBox: CheckboxTick,
+    ElemLabel: Label
+  },
+  'sliding-checkbox': {
+    className: slidingCheckboxInputStyles.input,
+    ElemBox: SlidingCheckboxTick,
     ElemLabel: Label
   }
 }
@@ -193,19 +261,21 @@ class InputField extends PureComponent<Props> {
     const inputId = id || name
     const labelId = inputId ? `label-${inputId}` : ''
     const errorClassName = isInvalid ? errorInput : ''
+    const finalType = getFinalType(type)
 
     if (isSpecialType(type)) {
       const { ElemBox, ElemLabel, className } = specialTypesDefinitions[type]
+
       return (
         FieldRoot(
           ElemLabel(
             Tag({
               className,
-              type,
               name,
               id: inputId,
               value,
               onChange,
+              type: finalType,
               'aria-labelledby': labelId,
               ...rest
             }),

--- a/src/components/forms/InputField.md
+++ b/src/components/forms/InputField.md
@@ -67,7 +67,7 @@ makeValueChangeHandler = option => () => setState(prev => ({ cb: !prev.cb }));
   type="sliding-checkbox"
   label="Sliding Checkbox"
   checked={state.cb}
-  onChange={makeValueChangeHandler(state.cb)}
+  onChange={console.log(state.cb) || makeValueChangeHandler(state.cb)}
 />
 ```
 

--- a/src/components/forms/InputField.md
+++ b/src/components/forms/InputField.md
@@ -57,6 +57,20 @@ makeValueChangeHandler = option => () => setState(prev => ({ cb: !prev.cb }));
 />
 ```
 
+Sliding Checkbox element:
+
+```js
+initialState = { cb: true };
+makeValueChangeHandler = option => () => setState(prev => ({ cb: !prev.cb }));
+
+<InputField
+  type="sliding-checkbox"
+  label="Sliding Checkbox"
+  checked={state.cb}
+  onChange={makeValueChangeHandler(state.cb)}
+/>
+```
+
 Invalid element:
 
 ```js

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -41,6 +41,7 @@ export default wrap({
   baseBrighter: palette.white,
   baseDarker: palette.haiti,
   baseRed: palette.radicalRed,
+  baseLightRed: palette.wePeep,
   baseGreen: palette.fern,
   baseSilver: palette.alto,
   baseHighlight: palette.mercury,
@@ -49,6 +50,9 @@ export default wrap({
   typoSubheading: palette.radicalRed,
   typoParagraph: palette.scarpaFlow,
   typoHighlight: palette.haiti,
+
+  sliderToggle: palette.bombay,
+  sliderBackground: palette.athensGray,
 
   formPlaceholder: palette.manatee,
   formText: palette.scarpaFlow,


### PR DESCRIPTION
Resolves: #132

This toggle switch component is implement as variation over simple `checkbox` input.
I added definitions object for these types variation, so `sliding-checkbox` type becomes `checkbox` in the DOM, but we can style it differently and use slightly different syntax.
This was particularly useful for this component, where I wanted underlying logic to be the same as if it was a checkbox, but wanted some complicated styling.

#### Video with demo
https://cl.ly/360b3J0A2f0M/Screen%20Recording%202018-05-04%20at%2003.34%20PM.mov