### PR TITLE
Add Note component

### DIFF
--- a/.snapguidist/__snapshots__/Note-1.snap
+++ b/.snapguidist/__snapshots__/Note-1.snap
@@ -1,0 +1,33 @@
+exports[`Note-1 1`] = `
+<div
+  className="AutoUI_ui_Note-23">
+  <div
+    className="AutoUI_ui_Note-27">
+    <img
+      alt="Samwise Gamgee"
+      src="https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg"
+      style={
+        Object {
+          "borderRadius": "50%",
+          "height": "100%",
+          "width": "100%",
+        }
+      } />
+  </div>
+  <div
+    className="AutoUI_ui_Note-42">
+    <span
+      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      Samwise Gamgee
+    </span>
+    <span
+      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      just now
+    </span>
+    <p
+      className="AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      One tiny Hobbit against all the evil the world could muster. A sane being would have given up, but Samwise burned with a magnificent madness, a glowing obsession to surmount every obstacle, to find Frodo, destroy the Ring, and cleanse Middle Earth of its festering malignancy. He knew he would try again. Fail, perhaps. And try once more. A thousand, thousand times if need be, but he would not give up the quest.
+    </p>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/Note-1.snap
+++ b/.snapguidist/__snapshots__/Note-1.snap
@@ -1,8 +1,8 @@
 exports[`Note-1 1`] = `
 <div
-  className="AutoUI_ui_Note-23">
+  className="AutoUI_ui_Note-21">
   <div
-    className="AutoUI_ui_Note-27">
+    className="AutoUI_ui_Note-25">
     <img
       alt="Samwise Gamgee"
       src="https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg"
@@ -15,13 +15,13 @@ exports[`Note-1 1`] = `
       } />
   </div>
   <div
-    className="AutoUI_ui_Note-42">
+    className="AutoUI_ui_Note-40">
     <span
-      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      className="AutoUI_ui_Note-45 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
       Samwise Gamgee
     </span>
     <span
-      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      className="AutoUI_ui_Note-55 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
       just now
     </span>
     <p

--- a/.snapguidist/__snapshots__/Note-3.snap
+++ b/.snapguidist/__snapshots__/Note-3.snap
@@ -1,0 +1,33 @@
+exports[`Note-3 1`] = `
+<div
+  className="AutoUI_ui_Note-23">
+  <div
+    className="AutoUI_ui_Note-27">
+    <img
+      alt="Samwise Gamgee"
+      src="https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg"
+      style={
+        Object {
+          "borderRadius": "50%",
+          "height": "100%",
+          "width": "100%",
+        }
+      } />
+  </div>
+  <div
+    className="AutoUI_ui_Note-42">
+    <span
+      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      Samwise Gamgee
+    </span>
+    <span
+      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      6 m ago
+    </span>
+    <p
+      className="AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      I feel like spring after winter, and sun on the leaves; and like trumpets and harps and all the songs I have ever heard!
+    </p>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/Note-3.snap
+++ b/.snapguidist/__snapshots__/Note-3.snap
@@ -1,8 +1,8 @@
 exports[`Note-3 1`] = `
 <div
-  className="AutoUI_ui_Note-23">
+  className="AutoUI_ui_Note-21">
   <div
-    className="AutoUI_ui_Note-27">
+    className="AutoUI_ui_Note-25">
     <img
       alt="Samwise Gamgee"
       src="https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg"
@@ -15,13 +15,13 @@ exports[`Note-3 1`] = `
       } />
   </div>
   <div
-    className="AutoUI_ui_Note-42">
+    className="AutoUI_ui_Note-40">
     <span
-      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      className="AutoUI_ui_Note-45 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
       Samwise Gamgee
     </span>
     <span
-      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      className="AutoUI_ui_Note-55 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
       6 m ago
     </span>
     <p

--- a/.snapguidist/__snapshots__/Note-5.snap
+++ b/.snapguidist/__snapshots__/Note-5.snap
@@ -1,0 +1,25 @@
+exports[`Note-5 1`] = `
+<div
+  className="AutoUI_ui_Note-23">
+  <div
+    className="AutoUI_ui_Note-27">
+    <div
+      className="AutoUI_ui_Note-35" />
+  </div>
+  <div
+    className="AutoUI_ui_Note-42">
+    <span
+      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      Samwise Gamgee
+    </span>
+    <span
+      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      2 h ago
+    </span>
+    <p
+      className="AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      Do you remember the Shire, Mr. Frodo? It\'ll be spring soon. And the orchards will be in blossom. And the birds will be nesting in the hazel thicket. And they\'ll be sowing the summer barley in the lower fields... and eating the first of the strawberries with cream. Do you remember the taste of strawberries?
+    </p>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/Note-5.snap
+++ b/.snapguidist/__snapshots__/Note-5.snap
@@ -1,19 +1,19 @@
 exports[`Note-5 1`] = `
 <div
-  className="AutoUI_ui_Note-23">
+  className="AutoUI_ui_Note-21">
   <div
-    className="AutoUI_ui_Note-27">
+    className="AutoUI_ui_Note-25">
     <div
-      className="AutoUI_ui_Note-35" />
+      className="AutoUI_ui_Note-33" />
   </div>
   <div
-    className="AutoUI_ui_Note-42">
+    className="AutoUI_ui_Note-40">
     <span
-      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      className="AutoUI_ui_Note-45 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
       Samwise Gamgee
     </span>
     <span
-      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      className="AutoUI_ui_Note-55 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
       2 h ago
     </span>
     <p

--- a/.snapguidist/__snapshots__/Note-7.snap
+++ b/.snapguidist/__snapshots__/Note-7.snap
@@ -1,8 +1,8 @@
 exports[`Note-7 1`] = `
 <div
-  className="AutoUI_ui_Note-23">
+  className="AutoUI_ui_Note-21">
   <div
-    className="AutoUI_ui_Note-27">
+    className="AutoUI_ui_Note-25">
     <img
       alt="Samwise Gamgee"
       src="https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg"
@@ -15,13 +15,13 @@ exports[`Note-7 1`] = `
       } />
   </div>
   <div
-    className="AutoUI_ui_Note-42">
+    className="AutoUI_ui_Note-40">
     <span
-      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      className="AutoUI_ui_Note-45 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
       Samwise Gamgee
     </span>
     <span
-      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      className="AutoUI_ui_Note-55 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
       4 Apr 18
     </span>
     <p

--- a/.snapguidist/__snapshots__/Note-7.snap
+++ b/.snapguidist/__snapshots__/Note-7.snap
@@ -1,0 +1,33 @@
+exports[`Note-7 1`] = `
+<div
+  className="AutoUI_ui_Note-23">
+  <div
+    className="AutoUI_ui_Note-27">
+    <img
+      alt="Samwise Gamgee"
+      src="https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg"
+      style={
+        Object {
+          "borderRadius": "50%",
+          "height": "100%",
+          "width": "100%",
+        }
+      } />
+  </div>
+  <div
+    className="AutoUI_ui_Note-42">
+    <span
+      className="AutoUI_ui_Note-47 AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22">
+      Samwise Gamgee
+    </span>
+    <span
+      className="AutoUI_ui_Note-57 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      4 Apr 18
+    </span>
+    <p
+      className="AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40">
+      There, peeping among the cloud-wrack above a dark tor high up in the mountains, Sam saw a white star twinkle for a while. The beauty of it smote his heart, as he looked up out of the forsaken land, and hope returned to him. For like a shaft, clear and cold, the thought pierced him that in the end the Shadow was only a small and passing thing: there was light and high beauty for ever beyond its reach.
+    </p>
+  </div>
+</div>
+`;

--- a/interfaces/date-fns.js
+++ b/interfaces/date-fns.js
@@ -1,0 +1,15 @@
+declare module 'date-fns/difference_in_seconds' {
+  declare function exports(date1: Date, date2: Date): number
+}
+
+declare module 'date-fns/difference_in_minutes' {
+  declare function exports(date1: Date, date2: Date): number
+}
+
+declare module 'date-fns/difference_in_hours' {
+  declare function exports(date1: Date, date2: Date): number
+}
+
+declare module 'date-fns/format' {
+  declare function exports(date: Date, format: string): string
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2744,6 +2744,11 @@
         "assert-plus": "1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://widen.jfrog.io/widen/api/npm/npm-virtual/date-fns/-/date-fns-1.29.0.tgz?dl=https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha1-EuYJzcuTUScxHQTTMzTilgoqVOY="
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "color": "^2.0.1",
     "crypto-js": "^3.1.9-1",
     "css-loader": "^0.28.9",
+    "date-fns": "^1.29.0",
     "medium-editor": "^5.23.3",
     "recompose": "^0.26.0",
     "webfontloader": "^1.6.28"

--- a/src/components/ui/Note.js
+++ b/src/components/ui/Note.js
@@ -11,8 +11,6 @@ import formatDate from 'date-fns/format'
 import type { Element } from 'react'
 const cmz = require('cmz')
 
-const UPDATE_INTERVAL_TIME = 60 * 1000 // 1 minute
-
 type Props = {
   avatar?: Element<*>,
   date?: Date,
@@ -82,18 +80,30 @@ const timeFromNow = date => {
 }
 
 class Note extends PureComponent<Props> {
-  interval: number
+  interval:? number
 
   static defaultProps = {
     avatar: PlaceholderAvatar()
   }
 
   componentDidMount () {
-    this.interval = setInterval(() => this.forceUpdate(), UPDATE_INTERVAL_TIME)
+    const { date } = this.props
+
+    if (date) {
+      const now = new Date()
+      const hoursDelta = differenceInHours(now, date)
+      if (hoursDelta < 1) {
+        this.interval = setInterval(() => this.forceUpdate(), 60 * 1000) // 1 minute
+      } else if (hoursDelta < 24) {
+        this.interval = setInterval(() => this.forceUpdate(), 20 * 60 * 1000) // 20 minutes
+      }
+    }
   }
 
   componentWillUnmount () {
-    clearInterval(this.interval)
+    if (this.interval) {
+      clearInterval(this.interval)
+    }
   }
 
   render () {

--- a/src/components/ui/Note.js
+++ b/src/components/ui/Note.js
@@ -1,0 +1,115 @@
+// @flow
+
+import { PureComponent } from 'react'
+import theme from '../../styles/theme'
+import typo from '../../styles/typo'
+import elem from '../../utils/elem'
+import differenceInSeconds from 'date-fns/difference_in_seconds'
+import differenceInMinutes from 'date-fns/difference_in_minutes'
+import differenceInHours from 'date-fns/difference_in_hours'
+import formatDate from 'date-fns/format'
+import type { Element } from 'react'
+const cmz = require('cmz')
+
+const UPDATE_INTERVAL_TIME = 60 * 1000 // 1 minute
+
+type Props = {
+  avatar?: Element<*>,
+  date?: Date,
+  name?: string,
+  text?: string
+}
+
+const Root = elem.div(cmz(`
+  display: flex
+`))
+
+const Avatar = elem.div(cmz(`
+  margin-right: 16px
+  max-height: 40px
+  max-width: 40px
+  min-height: 40px
+  min-width: 40px
+`))
+
+const PlaceholderAvatar = elem.div(cmz(`
+  background: ${theme.iconGray}
+  border-radius: 50%
+  height: 100%
+  width: 100%
+`))
+
+const Body = elem.div(cmz(`
+  display: flex
+  flex-direction: column
+`))
+
+const Name = elem.span(cmz(
+  typo.headline,
+  `
+    font-size: 16px
+    line-height: normal
+    margin: 0
+    text-transform: uppercase
+  `
+))
+
+const Time = elem.span(cmz(
+  typo.baseText,
+  `
+    font-size: 12px
+    line-height: 12px
+    margin-top: 8px
+  `
+))
+
+const Text = elem.p(typo.baseText)
+
+const timeFromNow = date => {
+  const now = new Date()
+  const hoursDelta = differenceInHours(now, date)
+  if (hoursDelta >= 24) {
+    return formatDate(date, 'D MMM YY')
+  }
+  const minutesDelta = differenceInMinutes(now, date)
+  if (minutesDelta >= 60) {
+    return `${hoursDelta} h ago`
+  }
+  if (differenceInSeconds(now, date) >= 60) {
+    return `${minutesDelta} m ago`
+  }
+  return 'just now'
+}
+
+class Note extends PureComponent<Props> {
+  interval: number
+
+  static defaultProps = {
+    avatar: PlaceholderAvatar()
+  }
+
+  componentDidMount () {
+    this.interval = setInterval(() => this.forceUpdate(), UPDATE_INTERVAL_TIME)
+  }
+
+  componentWillUnmount () {
+    clearInterval(this.interval)
+  }
+
+  render () {
+    const { avatar, date, name, text } = this.props
+
+    return (
+      Root(
+        Avatar(avatar),
+        Body(
+          name && Name(name),
+          date && Time(timeFromNow(date)),
+          text && Text(text)
+        )
+      )
+    )
+  }
+}
+
+export default Note

--- a/src/components/ui/Note.md
+++ b/src/components/ui/Note.md
@@ -1,0 +1,49 @@
+Just now:
+
+```js
+const date = new Date();
+<Note
+  avatar={ <img alt='Samwise Gamgee' src='https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg' style={ { borderRadius: '50%', height: '100%', width: '100%' } } /> }
+  date={date}
+  name='Samwise Gamgee'
+  text='One tiny Hobbit against all the evil the world could muster. A sane being would have given up, but Samwise burned with a magnificent madness, a glowing obsession to surmount every obstacle, to find Frodo, destroy the Ring, and cleanse Middle Earth of its festering malignancy. He knew he would try again. Fail, perhaps. And try once more. A thousand, thousand times if need be, but he would not give up the quest.'
+/>
+```
+
+6 minutes ago:
+
+```js
+const date = new Date();
+date.setDate(date.getDate() - 1/240);
+<Note
+  avatar={ <img alt='Samwise Gamgee' src='https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg' style={ { borderRadius: '50%', height: '100%', width: '100%' } } /> }
+  date={date}
+  name='Samwise Gamgee'
+  text='I feel like spring after winter, and sun on the leaves; and like trumpets and harps and all the songs I have ever heard!'
+/>
+```
+
+No avatar 2 hours ago:
+
+```js
+const date = new Date();
+date.setDate(date.getDate() - 1/12);
+<Note
+  date={date}
+  name='Samwise Gamgee'
+  text={`Do you remember the Shire, Mr. Frodo? It'll be spring soon. And the orchards will be in blossom. And the birds will be nesting in the hazel thicket. And they'll be sowing the summer barley in the lower fields... and eating the first of the strawberries with cream. Do you remember the taste of strawberries?`}
+/>
+```
+
+Older than 1 day:
+
+```js
+const date = new Date('2018-04-06T14:21:23.605Z');
+date.setDate(date.getDate() - 2);
+<Note
+  avatar={<img alt='Samwise Gamgee' src='https://pbs.twimg.com/profile_images/416334680598659072/-_RxK6dH_200x200.jpeg' style={ { borderRadius: '50%', height: '100%', width: '100%' } } />}
+  date={date}
+  name='Samwise Gamgee'
+  text='There, peeping among the cloud-wrack above a dark tor high up in the mountains, Sam saw a white star twinkle for a while. The beauty of it smote his heart, as he looked up out of the forsaken land, and hope returned to him. For like a shaft, clear and cold, the thought pierced him that in the end the Shadow was only a small and passing thing: there was light and high beauty for ever beyond its reach.'
+/>
+```


### PR DESCRIPTION
Fixes: x-team/auto-ui#127

----
<img width="585" alt="screen shot 2018-05-05 at 9 33 10 pm" src="https://user-images.githubusercontent.com/5314713/39669250-f6cccebe-50ab-11e8-9fa8-5f624e9b5727.png">

----


It looks like the header and text are styled differently than the mockup.  I am using the `typo.headline` and `typo.baseText` variables.

<img width="654" alt="screen shot 2018-05-05 at 9 36 44 pm" src="https://user-images.githubusercontent.com/5314713/39669265-8948ed7c-50ac-11e8-9a04-6a1b3e5b5d26.png">


New dependency: [date-fns](https://date-fns.org/)