### PR TITLE
Extend button styles

### DIFF
--- a/.snapguidist/__snapshots__/ApplicantScreen-3.snap
+++ b/.snapguidist/__snapshots__/ApplicantScreen-3.snap
@@ -246,9 +246,9 @@ exports[`ApplicantScreen-3 1`] = `
             </section>
             <div>
               <button
-                className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+                className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
                 <span
-                  className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+                  className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
                   Click here to go to next step
                 </span>
               </button>

--- a/.snapguidist/__snapshots__/ApplicantScreen-3.snap
+++ b/.snapguidist/__snapshots__/ApplicantScreen-3.snap
@@ -246,9 +246,9 @@ exports[`ApplicantScreen-3 1`] = `
             </section>
             <div>
               <button
-                className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+                className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
                 <span
-                  className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+                  className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
                   Click here to go to next step
                 </span>
               </button>

--- a/.snapguidist/__snapshots__/AttachFiles-1.snap
+++ b/.snapguidist/__snapshots__/AttachFiles-1.snap
@@ -279,9 +279,9 @@ exports[`AttachFiles-1 1`] = `
     className="AutoUI_ui_AttachFiles-74"
     type="file" />
   <button
-    className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-112 outlined">
+    className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
     <span
-      className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+      className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
       <span
         className="AutoUI_ui_AttachFiles-70">
         Attach a file

--- a/.snapguidist/__snapshots__/AttachFiles-1.snap
+++ b/.snapguidist/__snapshots__/AttachFiles-1.snap
@@ -279,9 +279,9 @@ exports[`AttachFiles-1 1`] = `
     className="AutoUI_ui_AttachFiles-74"
     type="file" />
   <button
-    className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
+    className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-139 outlined">
     <span
-      className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+      className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
       <span
         className="AutoUI_ui_AttachFiles-70">
         Attach a file

--- a/.snapguidist/__snapshots__/AttachFiles-3.snap
+++ b/.snapguidist/__snapshots__/AttachFiles-3.snap
@@ -4,9 +4,9 @@ exports[`AttachFiles-3 1`] = `
     className="AutoUI_ui_AttachFiles-74"
     type="file" />
   <button
-    className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
+    className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-139 outlined">
     <span
-      className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+      className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
       <span
         className="AutoUI_ui_AttachFiles-70">
         Attach a file

--- a/.snapguidist/__snapshots__/AttachFiles-3.snap
+++ b/.snapguidist/__snapshots__/AttachFiles-3.snap
@@ -4,9 +4,9 @@ exports[`AttachFiles-3 1`] = `
     className="AutoUI_ui_AttachFiles-74"
     type="file" />
   <button
-    className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-112 outlined">
+    className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
     <span
-      className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+      className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
       <span
         className="AutoUI_ui_AttachFiles-70">
         Attach a file

--- a/.snapguidist/__snapshots__/Button-1.snap
+++ b/.snapguidist/__snapshots__/Button-1.snap
@@ -1,8 +1,8 @@
 exports[`Button-1 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Normal state with default color
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-11.snap
+++ b/.snapguidist/__snapshots__/Button-11.snap
@@ -1,9 +1,9 @@
 exports[`Button-11 1`] = `
 <button
-  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-146">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-122 ">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Block size
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Large size
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-11.snap
+++ b/.snapguidist/__snapshots__/Button-11.snap
@@ -1,8 +1,8 @@
 exports[`Button-11 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-126">
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-146">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Block size
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-13.snap
+++ b/.snapguidist/__snapshots__/Button-13.snap
@@ -1,9 +1,9 @@
 exports[`Button-13 1`] = `
 <button
-  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-123">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-153">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Disabled state
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Block size
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-13.snap
+++ b/.snapguidist/__snapshots__/Button-13.snap
@@ -1,8 +1,8 @@
 exports[`Button-13 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-103">
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-123">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Disabled state
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-15.snap
+++ b/.snapguidist/__snapshots__/Button-15.snap
@@ -1,9 +1,9 @@
 exports[`Button-15 1`] = `
 <button
-  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-130">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Outlined default state
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Disabled state
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-15.snap
+++ b/.snapguidist/__snapshots__/Button-15.snap
@@ -1,8 +1,8 @@
 exports[`Button-15 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-112 outlined">
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Outlined default state
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-17.snap
+++ b/.snapguidist/__snapshots__/Button-17.snap
@@ -1,8 +1,8 @@
 exports[`Button-17 1`] = `
 <button
-  className=" AutoUI_ui_Button-47 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-112 outlined">
+  className=" AutoUI_ui_Button-49 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Outlined monochrome state
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-17.snap
+++ b/.snapguidist/__snapshots__/Button-17.snap
@@ -1,9 +1,9 @@
 exports[`Button-17 1`] = `
 <button
-  className=" AutoUI_ui_Button-49 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-159 rounded">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Outlined monochrome state
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Rounded default state
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-19.snap
+++ b/.snapguidist/__snapshots__/Button-19.snap
@@ -1,9 +1,9 @@
 exports[`Button-19 1`] = `
-<a
-  className=" AutoUI_ui_Button-47 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+<button
+  className=" AutoUI_ui_Button-86 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    custom default button state
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Outlined silver state
   </span>
-</a>
+</button>
 `;

--- a/.snapguidist/__snapshots__/Button-19.snap
+++ b/.snapguidist/__snapshots__/Button-19.snap
@@ -1,9 +1,9 @@
 exports[`Button-19 1`] = `
 <button
-  className=" AutoUI_ui_Button-86 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-163 raised">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Outlined silver state
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Raised default state
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-21.snap
+++ b/.snapguidist/__snapshots__/Button-21.snap
@@ -1,9 +1,9 @@
 exports[`Button-21 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+  className=" AutoUI_ui_Button-86 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Regular button with no props
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Outlined silver state
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-21.snap
+++ b/.snapguidist/__snapshots__/Button-21.snap
@@ -1,9 +1,9 @@
 exports[`Button-21 1`] = `
 <button
-  className=" AutoUI_ui_Button-86 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-139 outlined">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Outlined silver state
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Outlined default state
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-23.snap
+++ b/.snapguidist/__snapshots__/Button-23.snap
@@ -1,9 +1,9 @@
 exports[`Button-23 1`] = `
 <button
-  className=" AutoUI_ui_Button-86 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined AutoUI_ui_Button-152 rounded AutoUI_ui_Button-156 raised">
+  className=" AutoUI_ui_Button-50 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-139 outlined">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Outlined silver state
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Outlined monochrome state
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-23.snap
+++ b/.snapguidist/__snapshots__/Button-23.snap
@@ -1,8 +1,9 @@
 exports[`Button-23 1`] = `
 <button
-  className=" AutoUI_Button-79 AutoUI_Button-28 AutoUI_Button-101 AutoUI_Button-125">
-  <span>
-    Rounded default state
+  className=" AutoUI_ui_Button-86 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-132 outlined AutoUI_ui_Button-152 rounded AutoUI_ui_Button-156 raised">
+  <span
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Outlined silver state
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-25.snap
+++ b/.snapguidist/__snapshots__/Button-25.snap
@@ -1,9 +1,9 @@
 exports[`Button-25 1`] = `
-<a
-  className=" AutoUI_ui_Button-49 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+<button
+  className=" AutoUI_ui_Button-88 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-139 outlined">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    custom default button state
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Outlined silver state
   </span>
-</a>
+</button>
 `;

--- a/.snapguidist/__snapshots__/Button-25.snap
+++ b/.snapguidist/__snapshots__/Button-25.snap
@@ -1,8 +1,9 @@
 exports[`Button-25 1`] = `
-<button
-  className=" AutoUI_Button-60 AutoUI_Button-28 AutoUI_Button-101 AutoUI_Button-125">
-  <span>
-    Rounded monochome state
+<a
+  className=" AutoUI_ui_Button-49 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+  <span
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    custom default button state
   </span>
-</button>
+</a>
 `;

--- a/.snapguidist/__snapshots__/Button-27.snap
+++ b/.snapguidist/__snapshots__/Button-27.snap
@@ -1,9 +1,9 @@
 exports[`Button-27 1`] = `
-<button
-  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+<a
+  className=" AutoUI_ui_Button-50 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Regular button with no props
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    custom default button state
   </span>
-</button>
+</a>
 `;

--- a/.snapguidist/__snapshots__/Button-27.snap
+++ b/.snapguidist/__snapshots__/Button-27.snap
@@ -1,8 +1,9 @@
 exports[`Button-27 1`] = `
-<a
-  className=" AutoUI_Button-60 AutoUI_Button-28 AutoUI_Button-101 ">
-  <span>
-    custom default button state
+<button
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+  <span
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Regular button with no props
   </span>
-</a>
+</button>
 `;

--- a/.snapguidist/__snapshots__/Button-29.snap
+++ b/.snapguidist/__snapshots__/Button-29.snap
@@ -1,8 +1,9 @@
 exports[`Button-29 1`] = `
 <button
-  className=" AutoUI_Button-79 AutoUI_Button-28 AutoUI_Button-101 ">
-  <span>
-    Regular button with no props
+  className=" AutoUI_ui_Button-88 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-139 outlined AutoUI_ui_Button-159 rounded AutoUI_ui_Button-163 raised">
+  <span
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Androind
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-3.snap
+++ b/.snapguidist/__snapshots__/Button-3.snap
@@ -1,8 +1,8 @@
 exports[`Button-3 1`] = `
 <button
-  className=" AutoUI_ui_Button-47 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+  className=" AutoUI_ui_Button-49 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Normal state with monochrome color
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-3.snap
+++ b/.snapguidist/__snapshots__/Button-3.snap
@@ -1,9 +1,9 @@
 exports[`Button-3 1`] = `
 <button
-  className=" AutoUI_ui_Button-49 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+  className=" AutoUI_ui_Button-88 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Normal state with monochrome color
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Normal state with silver color
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-31.snap
+++ b/.snapguidist/__snapshots__/Button-31.snap
@@ -1,0 +1,9 @@
+exports[`Button-31 1`] = `
+<button
+  className=" AutoUI_ui_Button-88 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-139 outlined AutoUI_ui_Button-159 rounded AutoUI_ui_Button-163 raised AutoUI_ui_Button-169 selected">
+  <span
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Android
+  </span>
+</button>
+`;

--- a/.snapguidist/__snapshots__/Button-33.snap
+++ b/.snapguidist/__snapshots__/Button-33.snap
@@ -1,9 +1,9 @@
-exports[`Button-1 1`] = `
+exports[`Button-33 1`] = `
 <button
   className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
   <span
     className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Normal state with default color
+    Regular button with no props
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-35.snap
+++ b/.snapguidist/__snapshots__/Button-35.snap
@@ -1,9 +1,9 @@
-exports[`Button-1 1`] = `
+exports[`Button-35 1`] = `
 <button
   className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
   <span
     className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Normal state with default color
+    Regular button with no props
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-5.snap
+++ b/.snapguidist/__snapshots__/Button-5.snap
@@ -1,8 +1,8 @@
 exports[`Button-5 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-88 ">
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-108 ">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Small size
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-5.snap
+++ b/.snapguidist/__snapshots__/Button-5.snap
@@ -1,9 +1,9 @@
 exports[`Button-5 1`] = `
 <button
-  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-108 ">
+  className=" AutoUI_ui_Button-50 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Small size
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Normal state with monochrome color
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-7.snap
+++ b/.snapguidist/__snapshots__/Button-7.snap
@@ -1,8 +1,8 @@
 exports[`Button-7 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Normal size
   </span>
 </button>

--- a/.snapguidist/__snapshots__/Button-7.snap
+++ b/.snapguidist/__snapshots__/Button-7.snap
@@ -1,9 +1,9 @@
 exports[`Button-7 1`] = `
 <button
-  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-115 ">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Normal size
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Small size
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-9.snap
+++ b/.snapguidist/__snapshots__/Button-9.snap
@@ -1,9 +1,9 @@
 exports[`Button-9 1`] = `
 <button
-  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-115 ">
+  className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
   <span
-    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
-    Large size
+    className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    Normal size
   </span>
 </button>
 `;

--- a/.snapguidist/__snapshots__/Button-9.snap
+++ b/.snapguidist/__snapshots__/Button-9.snap
@@ -1,8 +1,8 @@
 exports[`Button-9 1`] = `
 <button
-  className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-95 ">
+  className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-115 ">
   <span
-    className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+    className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
     Large size
   </span>
 </button>

--- a/.snapguidist/__snapshots__/ColorPalette-1.snap
+++ b/.snapguidist/__snapshots__/ColorPalette-1.snap
@@ -41,6 +41,18 @@ exports[`ColorPalette-1 1`] = `
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40"
     style={
       Object {
+        "backgroundColor": "rgb(247, 217, 220)",
+      }
+    }>
+    <div
+      className="AutoUI_ui_ColorPalette-34">
+      baseLightRed
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40"
+    style={
+      Object {
         "backgroundColor": "rgb(92, 184, 92)",
       }
     }>
@@ -119,6 +131,30 @@ exports[`ColorPalette-1 1`] = `
     <div
       className="AutoUI_ui_ColorPalette-34">
       typoHighlight
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40"
+    style={
+      Object {
+        "backgroundColor": "rgb(178, 182, 188)",
+      }
+    }>
+    <div
+      className="AutoUI_ui_ColorPalette-34">
+      sliderToggle
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40"
+    style={
+      Object {
+        "backgroundColor": "rgb(240, 241, 244)",
+      }
+    }>
+    <div
+      className="AutoUI_ui_ColorPalette-34">
+      sliderBackground
     </div>
   </div>
   <div

--- a/.snapguidist/__snapshots__/ColorPalette-1.snap
+++ b/.snapguidist/__snapshots__/ColorPalette-1.snap
@@ -29,6 +29,18 @@ exports[`ColorPalette-1 1`] = `
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40"
     style={
       Object {
+        "backgroundColor": "rgb(0, 0, 0)",
+      }
+    }>
+    <div
+      className="AutoUI_ui_ColorPalette-34">
+      baseDark
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-168 AutoUI_typo-53 AutoUI_typo-40"
+    style={
+      Object {
         "backgroundColor": "rgb(246, 57, 84)",
       }
     }>

--- a/.snapguidist/__snapshots__/MilestonesScreen-1.snap
+++ b/.snapguidist/__snapshots__/MilestonesScreen-1.snap
@@ -182,9 +182,9 @@ exports[`MilestonesScreen-1 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+            className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
             <span
-              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step 2
             </span>
           </button>

--- a/.snapguidist/__snapshots__/MilestonesScreen-1.snap
+++ b/.snapguidist/__snapshots__/MilestonesScreen-1.snap
@@ -182,9 +182,9 @@ exports[`MilestonesScreen-1 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
             <span
-              className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step 2
             </span>
           </button>

--- a/.snapguidist/__snapshots__/MilestonesScreen-3.snap
+++ b/.snapguidist/__snapshots__/MilestonesScreen-3.snap
@@ -182,9 +182,9 @@ exports[`MilestonesScreen-3 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
             <span
-              className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step 3
             </span>
           </button>
@@ -205,9 +205,9 @@ exports[`MilestonesScreen-3 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
             <span
-              className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step 3
             </span>
           </button>

--- a/.snapguidist/__snapshots__/MilestonesScreen-3.snap
+++ b/.snapguidist/__snapshots__/MilestonesScreen-3.snap
@@ -182,9 +182,9 @@ exports[`MilestonesScreen-3 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+            className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
             <span
-              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step 3
             </span>
           </button>
@@ -205,9 +205,9 @@ exports[`MilestonesScreen-3 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+            className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
             <span
-              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step 3
             </span>
           </button>

--- a/.snapguidist/__snapshots__/MilestonesScreen-5.snap
+++ b/.snapguidist/__snapshots__/MilestonesScreen-5.snap
@@ -182,9 +182,9 @@ exports[`MilestonesScreen-5 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+            className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
             <span
-              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step N+1
             </span>
           </button>
@@ -205,9 +205,9 @@ exports[`MilestonesScreen-5 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+            className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
             <span
-              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step N+1
             </span>
           </button>
@@ -228,9 +228,9 @@ exports[`MilestonesScreen-5 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
+            className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 ">
             <span
-              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step N+1
             </span>
           </button>

--- a/.snapguidist/__snapshots__/MilestonesScreen-5.snap
+++ b/.snapguidist/__snapshots__/MilestonesScreen-5.snap
@@ -182,9 +182,9 @@ exports[`MilestonesScreen-5 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
             <span
-              className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step N+1
             </span>
           </button>
@@ -205,9 +205,9 @@ exports[`MilestonesScreen-5 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
             <span
-              className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step N+1
             </span>
           </button>
@@ -228,9 +228,9 @@ exports[`MilestonesScreen-5 1`] = `
         </section>
         <div>
           <button
-            className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 ">
+            className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 ">
             <span
-              className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+              className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
               Go to the step N+1
             </span>
           </button>

--- a/.snapguidist/__snapshots__/Roadmap-1.snap
+++ b/.snapguidist/__snapshots__/Roadmap-1.snap
@@ -642,10 +642,10 @@ exports[`Roadmap-1 1`] = `
           </div>
         </section>
         <button
-          className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-126"
+          className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-146"
           data-test="roadmapStart">
           <span
-            className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+            className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
             Let\'s do this.
           </span>
         </button>

--- a/.snapguidist/__snapshots__/Roadmap-1.snap
+++ b/.snapguidist/__snapshots__/Roadmap-1.snap
@@ -642,10 +642,10 @@ exports[`Roadmap-1 1`] = `
           </div>
         </section>
         <button
-          className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-146"
+          className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-153"
           data-test="roadmapStart">
           <span
-            className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+            className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
             Let\'s do this.
           </span>
         </button>

--- a/.snapguidist/__snapshots__/RoadmapLevel-5.snap
+++ b/.snapguidist/__snapshots__/RoadmapLevel-5.snap
@@ -58,10 +58,10 @@ exports[`RoadmapLevel-5 1`] = `
     </div>
   </section>
   <button
-    className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-126"
+    className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-146"
     data-test="roadmapStart">
     <span
-      className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+      className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
       Let\'s do this.
     </span>
   </button>

--- a/.snapguidist/__snapshots__/RoadmapLevel-5.snap
+++ b/.snapguidist/__snapshots__/RoadmapLevel-5.snap
@@ -58,10 +58,10 @@ exports[`RoadmapLevel-5 1`] = `
     </div>
   </section>
   <button
-    className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-146"
+    className="AutoUI_ui_RoadmapLevel-51 AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-153"
     data-test="roadmapStart">
     <span
-      className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+      className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
       Let\'s do this.
     </span>
   </button>

--- a/.snapguidist/__snapshots__/SolutionForm-1.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-1.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-1 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-103"
+      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-123"
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (1 of 3)
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-1.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-1.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-1 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-123"
+      className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-130"
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (1 of 3)
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-3.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-3.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-3 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 "
+      className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 "
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (1 of 5)
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-3.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-3.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-3 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 "
+      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 "
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (1 of 5)
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-5.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-5.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-5 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 "
+      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 "
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (3 of 3)
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-5.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-5.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-5 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 "
+      className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 "
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (3 of 3)
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-7.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-7.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-7 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 AutoUI_ui_Button-103"
+      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-123"
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Checking...
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-7.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-7.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-7 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 AutoUI_ui_Button-123"
+      className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 AutoUI_ui_Button-130"
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Checking...
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-9.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-9.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-9 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-66 AutoUI_ui_Button-28 AutoUI_ui_Button-93 "
+      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 "
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-42 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (1 of 3)
       </span>
     </button>

--- a/.snapguidist/__snapshots__/SolutionForm-9.snap
+++ b/.snapguidist/__snapshots__/SolutionForm-9.snap
@@ -22,10 +22,10 @@ exports[`SolutionForm-9 1`] = `
       name="solution"
       placeholder="Paste your solution here." />
     <button
-      className=" AutoUI_ui_Button-68 AutoUI_ui_Button-30 AutoUI_ui_Button-113 "
+      className=" AutoUI_ui_Button-69 AutoUI_ui_Button-31 AutoUI_ui_Button-120 "
       data-test="solutionSubmit">
       <span
-        className="AutoUI_ui_Button-44 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
+        className="AutoUI_ui_Button-45 AutoUI_typo-157 AutoUI_typo-53 AutoUI_typo-46">
         Submit (1 of 3)
       </span>
     </button>

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -193,6 +193,7 @@ function wrap(theme) {
  */
 var palette = {
   white: '#FFF',
+  black: '#000',
   haiti: '#130E2E',
   fern: '#5CB85C',
   radicalRed: '#F63954',
@@ -213,6 +214,7 @@ var palette = {
 exports.default = wrap({
   baseBrighter: palette.white,
   baseDarker: palette.haiti,
+  baseDark: palette.black,
   baseRed: palette.radicalRed,
   baseLightRed: palette.wePeep,
   baseGreen: palette.fern,
@@ -937,36 +939,39 @@ function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in ob
 var cmz = __webpack_require__(1);
 
 var baseStyles = {
-  root: cmz.named('AutoUI_ui_Button-30', /*cmz|*/'\n    display: inline-block;\n    border: 2px solid transparent;\n    background: transparent;\n    text-align: center;\n    outline: none;\n    margin: 2px auto;\n    padding: 10px 19px;\n    text-decoration: none;\n    cursor: pointer;\n    white-space: nowrap;\n    transition: all .3s ease-out;\n  ' /*|cmz*/),
+  root: cmz.named('AutoUI_ui_Button-31', /*cmz|*/'\n    display: inline-block\n    border: 2px solid transparent\n    background: transparent\n    text-align: center\n    outline: none\n    margin: 2px auto\n    padding: 10px 19px\n    text-decoration: none\n    cursor: pointer\n    white-space: nowrap\n    transition: all .3s ease-out\n  ' /*|cmz*/),
 
-  content: cmz.named('AutoUI_ui_Button-44', _typo2.default.labelText, /*cmz|*/'font-size: inherit' /*|cmz*/)
+  content: cmz.named('AutoUI_ui_Button-45', _typo2.default.labelText, /*cmz|*/'font-size: inherit' /*|cmz*/)
 
   // Color options
 };var colorStyles = {
-  monochrome: cmz.named('AutoUI_ui_Button-49', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseDarker + ';\n      border-color: ' + _theme2.default.baseDarker + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseDarker + '\n    }\n\n    &:not(.raised):hover {\n      background-color: ' + _theme2.default.baseDarker.lighten(0.5) + ';\n      border-color: ' + _theme2.default.baseDarker.lighten(0.5) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  '),
+  monochrome: cmz.named('AutoUI_ui_Button-50', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseDarker + '\n      border-color: ' + _theme2.default.baseDarker + '\n      color: ' + _theme2.default.baseBrighter + '\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseDarker + '\n    }\n\n    &:hover {\n      background-color: ' + _theme2.default.baseDarker.lighten(0.5) + '\n      border-color: ' + _theme2.default.baseDarker.lighten(0.5) + '\n      color: ' + _theme2.default.baseBrighter + '\n    }\n  '),
 
-  normal: cmz.named('AutoUI_ui_Button-68', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseRed + ';\n      border-color: ' + _theme2.default.baseRed + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseRed + '\n    }\n\n    &:not(.raised):hover {\n      background-color: ' + _theme2.default.baseRed.darken(0.2) + ';\n      border-color: ' + _theme2.default.baseRed.darken(0.2) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  '),
-  silver: cmz.named('AutoUI_ui_Button-86', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.lineSilver2 + ';\n      border-color: ' + _theme2.default.lineSilver2 + ';\n      color: ' + _theme2.default.iconGray + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.iconGray + '\n    }\n\n    &:not(.raised):hover {\n      background-color: ' + _theme2.default.lineSilver2.darken(0.2) + ';\n      border-color: ' + _theme2.default.lineSilver2.darken(0.2) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  ')
+  normal: cmz.named('AutoUI_ui_Button-69', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseRed + '\n      border-color: ' + _theme2.default.baseRed + '\n      color: ' + _theme2.default.baseBrighter + '\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseRed + '\n    }\n\n    &:hover {\n      background-color: ' + _theme2.default.baseRed.darken(0.2) + '\n      border-color: ' + _theme2.default.baseRed.darken(0.2) + '\n      color: ' + _theme2.default.baseBrighter + '\n    }\n  '),
+
+  silver: cmz.named('AutoUI_ui_Button-88', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.lineSilver2 + '\n      border-color: ' + _theme2.default.lineSilver2 + '\n      color: ' + _theme2.default.baseDark + '\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseDark + '\n    }\n\n    &.outlined.raised:hover {\n      background-color: transparent\n      border-color: transparent\n    }\n\n    &:hover {\n      background-color: ' + _theme2.default.lineSilver2.darken(0.025) + '\n      border-color: ' + _theme2.default.lineSilver2.darken(0.025) + '\n      color: ' + _theme2.default.baseDark + '\n    }\n  ')
 
   // Size options
 };var sizeStyles = {
-  small: cmz.named('AutoUI_ui_Button-108', /*cmz|*/'\n    font-size: 10px !important\n    padding: 8px 16px\n  ' /*|cmz*/),
+  small: cmz.named('AutoUI_ui_Button-115', /*cmz|*/'\n    font-size: 10px !important\n    padding: 8px 16px\n  ' /*|cmz*/),
 
-  normal: cmz.named('AutoUI_ui_Button-113', /*cmz|*/'font-size: 12px !important' /*|cmz*/),
+  normal: cmz.named('AutoUI_ui_Button-120', /*cmz|*/'font-size: 12px !important' /*|cmz*/),
 
-  large: cmz.named('AutoUI_ui_Button-115', /*cmz|*/'\n    font-size: 16px !important\n    padding: 14px 24px\n  ' /*|cmz*/)
+  large: cmz.named('AutoUI_ui_Button-122', /*cmz|*/'\n    font-size: 16px !important\n    padding: 14px 24px\n  ' /*|cmz*/)
 
   // Button variations
 };var extraStyles = {
-  disabled: cmz.named('AutoUI_ui_Button-123', '\n    &, &:hover {\n      background: ' + _theme2.default.baseHighlight + ';\n      border-color: transparent;\n      color: ' + _theme2.default.baseBrighter + ';\n      pointer-events: none;\n    }\n  '),
+  disabled: cmz.named('AutoUI_ui_Button-130', '\n    &, &:hover {\n      background: ' + _theme2.default.baseHighlight + '\n      border-color: transparent\n      color: ' + _theme2.default.baseBrighter + '\n      pointer-events: none\n    }\n  '),
 
-  outlined: cmz.named('AutoUI_ui_Button-132', '\n    & {\n      background-color: transparent;\n    }\n\n    &.' + colorStyles.normal + ' {\n      color: ' + _theme2.default.baseRed + ';\n    }\n\n    &.' + colorStyles.monochrome + ' {\n      color: ' + _theme2.default.baseDarker + ';\n    }\n  '),
+  outlined: cmz.named('AutoUI_ui_Button-139', '\n    & {\n      background-color: transparent\n    }\n\n    &.' + colorStyles.normal + ' {\n      color: ' + _theme2.default.baseRed + '\n    }\n\n    &.' + colorStyles.monochrome + ' {\n      color: ' + _theme2.default.baseDarker + '\n    }\n  '),
 
-  block: cmz.named('AutoUI_ui_Button-146', /*cmz|*/'\n    display: block\n    margin: 10px auto\n    width: 200px\n  ' /*|cmz*/),
+  block: cmz.named('AutoUI_ui_Button-153', /*cmz|*/'\n    display: block\n    margin: 10px auto\n    width: 200px\n  ' /*|cmz*/),
 
-  rounded: cmz.named('AutoUI_ui_Button-152', /*cmz|*/'\n    border-radius: 4px\n  ' /*|cmz*/),
+  rounded: cmz.named('AutoUI_ui_Button-159', /*cmz|*/'\n    border-radius: 4px\n  ' /*|cmz*/),
 
-  raised: cmz.named('AutoUI_ui_Button-156', /*cmz|*/'\n    &:hover {\n      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);\n    }\n' /*|cmz*/)
+  raised: cmz.named('AutoUI_ui_Button-163', /*cmz|*/'\n    &:hover {\n      box-shadow: 0 2px 10px 1px rgba(0, 0, 0, .08)\n    }\n  ' /*|cmz*/),
+
+  selected: cmz.named('AutoUI_ui_Button-169', '\n    & {\n      border-color: ' + _theme2.default.baseRed + '\n    }\n\n    &.outlined.raised:hover {\n      box-shadow: none\n      border-color: ' + _theme2.default.baseRed + '\n    }\n  ')
 };
 
 var Button = function (_PureComponent) {
@@ -989,14 +994,15 @@ var Button = function (_PureComponent) {
           disabled = _props.disabled,
           rounded = _props.rounded,
           raised = _props.raised,
+          selected = _props.selected,
           block = _props.block,
           CustomComponent = _props.component,
           children = _props.children,
-          rest = _objectWithoutProperties(_props, ['className', 'size', 'color', 'outlined', 'disabled', 'rounded', 'raised', 'block', 'component', 'children']);
+          rest = _objectWithoutProperties(_props, ['className', 'size', 'color', 'outlined', 'disabled', 'rounded', 'raised', 'selected', 'block', 'component', 'children']);
 
       var colorClassName = colorStyles[color] || '';
       var sizeClassName = sizeStyles[size] || '';
-      var extraClassName = [outlined && extraStyles.outlined, outlined && 'outlined', rounded && extraStyles.rounded, rounded && 'rounded', raised && extraStyles.raised, raised && 'raised', block && extraStyles.block, disabled && extraStyles.disabled].filter(Boolean).join(' ');
+      var extraClassName = [outlined && extraStyles.outlined, outlined && 'outlined', rounded && extraStyles.rounded, rounded && 'rounded', raised && extraStyles.raised, raised && 'raised', selected && extraStyles.selected, selected && 'selected', block && extraStyles.block, disabled && extraStyles.disabled].filter(Boolean).join(' ');
       var buttonClassName = colorClassName + ' ' + sizeClassName + ' ' + extraClassName;
 
       return _react2.default.createElement(
@@ -1023,6 +1029,7 @@ Button.defaultProps = {
   disabled: false,
   rounded: false,
   raised: false,
+  selected: false,
   block: false
 };
 exports.default = Button;

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -937,31 +937,36 @@ function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in ob
 var cmz = __webpack_require__(1);
 
 var baseStyles = {
-  root: cmz.named('AutoUI_ui_Button-28', /*cmz|*/'\n    display: inline-block;\n    border: 2px solid transparent;\n    background: transparent;\n    text-align: center;\n    outline: none;\n    margin: 2px auto;\n    padding: 10px 19px;\n    text-decoration: none;\n    cursor: pointer;\n    white-space: nowrap;\n    transition: all .3s ease-out;\n  ' /*|cmz*/),
+  root: cmz.named('AutoUI_ui_Button-30', /*cmz|*/'\n    display: inline-block;\n    border: 2px solid transparent;\n    background: transparent;\n    text-align: center;\n    outline: none;\n    margin: 2px auto;\n    padding: 10px 19px;\n    text-decoration: none;\n    cursor: pointer;\n    white-space: nowrap;\n    transition: all .3s ease-out;\n  ' /*|cmz*/),
 
-  content: cmz.named('AutoUI_ui_Button-42', _typo2.default.labelText, /*cmz|*/'font-size: inherit' /*|cmz*/)
+  content: cmz.named('AutoUI_ui_Button-44', _typo2.default.labelText, /*cmz|*/'font-size: inherit' /*|cmz*/)
 
   // Color options
 };var colorStyles = {
-  monochrome: cmz.named('AutoUI_ui_Button-47', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseDarker + ';\n      border-color: ' + _theme2.default.baseDarker + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseDarker + '\n    }\n\n    &:hover {\n      background-color: ' + _theme2.default.baseDarker.lighten(0.5) + ';\n      border-color: ' + _theme2.default.baseDarker.lighten(0.5) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  '),
+  monochrome: cmz.named('AutoUI_ui_Button-49', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseDarker + ';\n      border-color: ' + _theme2.default.baseDarker + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseDarker + '\n    }\n\n    &:not(.raised):hover {\n      background-color: ' + _theme2.default.baseDarker.lighten(0.5) + ';\n      border-color: ' + _theme2.default.baseDarker.lighten(0.5) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  '),
 
-  normal: cmz.named('AutoUI_ui_Button-66', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseRed + ';\n      border-color: ' + _theme2.default.baseRed + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseRed + '\n    }\n\n    &:hover {\n      background-color: ' + _theme2.default.baseRed.darken(0.2) + ';\n      border-color: ' + _theme2.default.baseRed.darken(0.2) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  ')
+  normal: cmz.named('AutoUI_ui_Button-68', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.baseRed + ';\n      border-color: ' + _theme2.default.baseRed + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.baseRed + '\n    }\n\n    &:not(.raised):hover {\n      background-color: ' + _theme2.default.baseRed.darken(0.2) + ';\n      border-color: ' + _theme2.default.baseRed.darken(0.2) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  '),
+  silver: cmz.named('AutoUI_ui_Button-86', baseStyles.root, '\n    & {\n      background-color: ' + _theme2.default.lineSilver2 + ';\n      border-color: ' + _theme2.default.lineSilver2 + ';\n      color: ' + _theme2.default.iconGray + ';\n    }\n\n    &.outlined {\n      color: ' + _theme2.default.iconGray + '\n    }\n\n    &:not(.raised):hover {\n      background-color: ' + _theme2.default.lineSilver2.darken(0.2) + ';\n      border-color: ' + _theme2.default.lineSilver2.darken(0.2) + ';\n      color: ' + _theme2.default.baseBrighter + ';\n    }\n  ')
 
   // Size options
 };var sizeStyles = {
-  small: cmz.named('AutoUI_ui_Button-88', /*cmz|*/'\n    font-size: 10px !important\n    padding: 8px 16px\n  ' /*|cmz*/),
+  small: cmz.named('AutoUI_ui_Button-108', /*cmz|*/'\n    font-size: 10px !important\n    padding: 8px 16px\n  ' /*|cmz*/),
 
-  normal: cmz.named('AutoUI_ui_Button-93', /*cmz|*/'font-size: 12px !important' /*|cmz*/),
+  normal: cmz.named('AutoUI_ui_Button-113', /*cmz|*/'font-size: 12px !important' /*|cmz*/),
 
-  large: cmz.named('AutoUI_ui_Button-95', /*cmz|*/'\n    font-size: 16px !important\n    padding: 14px 24px\n  ' /*|cmz*/)
+  large: cmz.named('AutoUI_ui_Button-115', /*cmz|*/'\n    font-size: 16px !important\n    padding: 14px 24px\n  ' /*|cmz*/)
 
   // Button variations
 };var extraStyles = {
-  disabled: cmz.named('AutoUI_ui_Button-103', '\n    &, &:hover {\n      background: ' + _theme2.default.baseHighlight + ';\n      border-color: transparent;\n      color: ' + _theme2.default.baseBrighter + ';\n      pointer-events: none;\n    }\n  '),
+  disabled: cmz.named('AutoUI_ui_Button-123', '\n    &, &:hover {\n      background: ' + _theme2.default.baseHighlight + ';\n      border-color: transparent;\n      color: ' + _theme2.default.baseBrighter + ';\n      pointer-events: none;\n    }\n  '),
 
-  outlined: cmz.named('AutoUI_ui_Button-112', '\n    & {\n      background-color: transparent;\n    }\n\n    &.' + colorStyles.normal + ' {\n      color: ' + _theme2.default.baseRed + ';\n    }\n\n    &.' + colorStyles.monochrome + ' {\n      color: ' + _theme2.default.baseDarker + ';\n    }\n  '),
+  outlined: cmz.named('AutoUI_ui_Button-132', '\n    & {\n      background-color: transparent;\n    }\n\n    &.' + colorStyles.normal + ' {\n      color: ' + _theme2.default.baseRed + ';\n    }\n\n    &.' + colorStyles.monochrome + ' {\n      color: ' + _theme2.default.baseDarker + ';\n    }\n  '),
 
-  block: cmz.named('AutoUI_ui_Button-126', /*cmz|*/'\n    display: block\n    margin: 10px auto\n    width: 200px\n  ' /*|cmz*/)
+  block: cmz.named('AutoUI_ui_Button-146', /*cmz|*/'\n    display: block\n    margin: 10px auto\n    width: 200px\n  ' /*|cmz*/),
+
+  rounded: cmz.named('AutoUI_ui_Button-152', /*cmz|*/'\n    border-radius: 4px\n  ' /*|cmz*/),
+
+  raised: cmz.named('AutoUI_ui_Button-156', /*cmz|*/'\n    &:hover {\n      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);\n    }\n' /*|cmz*/)
 };
 
 var Button = function (_PureComponent) {
@@ -982,14 +987,16 @@ var Button = function (_PureComponent) {
           color = _props.color,
           outlined = _props.outlined,
           disabled = _props.disabled,
+          rounded = _props.rounded,
+          raised = _props.raised,
           block = _props.block,
           CustomComponent = _props.component,
           children = _props.children,
-          rest = _objectWithoutProperties(_props, ['className', 'size', 'color', 'outlined', 'disabled', 'block', 'component', 'children']);
+          rest = _objectWithoutProperties(_props, ['className', 'size', 'color', 'outlined', 'disabled', 'rounded', 'raised', 'block', 'component', 'children']);
 
       var colorClassName = colorStyles[color] || '';
       var sizeClassName = sizeStyles[size] || '';
-      var extraClassName = [outlined && extraStyles.outlined, outlined && 'outlined', block && extraStyles.block, disabled && extraStyles.disabled].filter(Boolean).join(' ');
+      var extraClassName = [outlined && extraStyles.outlined, outlined && 'outlined', rounded && extraStyles.rounded, rounded && 'rounded', raised && extraStyles.raised, raised && 'raised', block && extraStyles.block, disabled && extraStyles.disabled].filter(Boolean).join(' ');
       var buttonClassName = colorClassName + ' ' + sizeClassName + ' ' + extraClassName;
 
       return _react2.default.createElement(
@@ -1014,6 +1021,8 @@ Button.defaultProps = {
   size: 'normal',
   outlined: false,
   disabled: false,
+  rounded: false,
+  raised: false,
   block: false
 };
 exports.default = Button;

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -20,6 +20,7 @@ type Props = {
   outlined: ?boolean,
   rounded: ?boolean,
   raised: ?boolean,
+  selected: ?boolean,
   disabled: ?boolean,
   block: ?boolean,
   component: string,
@@ -28,17 +29,17 @@ type Props = {
 
 const baseStyles = {
   root: cmz(`
-    display: inline-block;
-    border: 2px solid transparent;
-    background: transparent;
-    text-align: center;
-    outline: none;
-    margin: 2px auto;
-    padding: 10px 19px;
-    text-decoration: none;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: all .3s ease-out;
+    display: inline-block
+    border: 2px solid transparent
+    background: transparent
+    text-align: center
+    outline: none
+    margin: 2px auto
+    padding: 10px 19px
+    text-decoration: none
+    cursor: pointer
+    white-space: nowrap
+    transition: all .3s ease-out
   `),
 
   content: cmz(typo.labelText, 'font-size: inherit')
@@ -49,56 +50,62 @@ const colorStyles = {
   monochrome: cmz(
     baseStyles.root, `
     & {
-      background-color: ${theme.baseDarker};
-      border-color: ${theme.baseDarker};
-      color: ${theme.baseBrighter};
+      background-color: ${theme.baseDarker}
+      border-color: ${theme.baseDarker}
+      color: ${theme.baseBrighter}
     }
 
     &.outlined {
       color: ${theme.baseDarker}
     }
 
-    &:not(.raised):hover {
-      background-color: ${theme.baseDarker.lighten(0.5)};
-      border-color: ${theme.baseDarker.lighten(0.5)};
-      color: ${theme.baseBrighter};
+    &:hover {
+      background-color: ${theme.baseDarker.lighten(0.5)}
+      border-color: ${theme.baseDarker.lighten(0.5)}
+      color: ${theme.baseBrighter}
     }
   `),
 
   normal: cmz(
     baseStyles.root, `
     & {
-      background-color: ${theme.baseRed};
-      border-color: ${theme.baseRed};
-      color: ${theme.baseBrighter};
+      background-color: ${theme.baseRed}
+      border-color: ${theme.baseRed}
+      color: ${theme.baseBrighter}
     }
 
     &.outlined {
       color: ${theme.baseRed}
     }
 
-    &:not(.raised):hover {
-      background-color: ${theme.baseRed.darken(0.2)};
-      border-color: ${theme.baseRed.darken(0.2)};
-      color: ${theme.baseBrighter};
+    &:hover {
+      background-color: ${theme.baseRed.darken(0.2)}
+      border-color: ${theme.baseRed.darken(0.2)}
+      color: ${theme.baseBrighter}
     }
   `),
+
   silver: cmz(
     baseStyles.root, `
     & {
-      background-color: ${theme.lineSilver2};
-      border-color: ${theme.lineSilver2};
-      color: ${theme.iconGray};
+      background-color: ${theme.lineSilver2}
+      border-color: ${theme.lineSilver2}
+      color: ${theme.baseDark}
     }
 
     &.outlined {
-      color: ${theme.iconGray}
+      color: ${theme.baseDark}
     }
 
-    &:not(.raised):hover {
-      background-color: ${theme.lineSilver2.darken(0.2)};
-      border-color: ${theme.lineSilver2.darken(0.2)};
-      color: ${theme.baseBrighter};
+    &.outlined.raised:hover {
+      background-color: transparent
+      border-color: transparent
+    }
+
+    &:hover {
+      background-color: ${theme.lineSilver2.darken(0.025)}
+      border-color: ${theme.lineSilver2.darken(0.025)}
+      color: ${theme.baseDark}
     }
   `)
 }
@@ -122,24 +129,24 @@ const sizeStyles = {
 const extraStyles = {
   disabled: cmz(`
     &, &:hover {
-      background: ${theme.baseHighlight};
-      border-color: transparent;
-      color: ${theme.baseBrighter};
-      pointer-events: none;
+      background: ${theme.baseHighlight}
+      border-color: transparent
+      color: ${theme.baseBrighter}
+      pointer-events: none
     }
   `),
 
   outlined: cmz(`
     & {
-      background-color: transparent;
+      background-color: transparent
     }
 
     &.${colorStyles.normal} {
-      color: ${theme.baseRed};
+      color: ${theme.baseRed}
     }
 
     &.${colorStyles.monochrome} {
-      color: ${theme.baseDarker};
+      color: ${theme.baseDarker}
     }
   `),
 
@@ -155,9 +162,20 @@ const extraStyles = {
 
   raised: cmz(`
     &:hover {
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+      box-shadow: 0 2px 10px 1px rgba(0, 0, 0, .08)
     }
-`)
+  `),
+
+  selected: cmz(`
+    & {
+      border-color: ${theme.baseRed}
+    }
+
+    &.outlined.raised:hover {
+      box-shadow: none
+      border-color: ${theme.baseRed}
+    }
+  `)
 }
 
 class Button extends PureComponent<Props> {
@@ -170,6 +188,7 @@ class Button extends PureComponent<Props> {
     disabled: false,
     rounded: false,
     raised: false,
+    selected: false,
     block: false
   }
 
@@ -182,6 +201,7 @@ class Button extends PureComponent<Props> {
       disabled,
       rounded,
       raised,
+      selected,
       block,
       component: CustomComponent,
       children,
@@ -197,6 +217,8 @@ class Button extends PureComponent<Props> {
       rounded && 'rounded',
       raised && extraStyles.raised,
       raised && 'raised',
+      selected && extraStyles.selected,
+      selected && 'selected',
       block && extraStyles.block,
       disabled && extraStyles.disabled
     ].filter(Boolean).join(' ')

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -18,6 +18,8 @@ type Props = {
   size: Size,
   color: Color,
   outlined: ?boolean,
+  rounded: ?boolean,
+  raised: ?boolean,
   disabled: ?boolean,
   block: ?boolean,
   component: string,
@@ -56,7 +58,7 @@ const colorStyles = {
       color: ${theme.baseDarker}
     }
 
-    &:hover {
+    &:not(.raised):hover {
       background-color: ${theme.baseDarker.lighten(0.5)};
       border-color: ${theme.baseDarker.lighten(0.5)};
       color: ${theme.baseBrighter};
@@ -75,9 +77,27 @@ const colorStyles = {
       color: ${theme.baseRed}
     }
 
-    &:hover {
+    &:not(.raised):hover {
       background-color: ${theme.baseRed.darken(0.2)};
       border-color: ${theme.baseRed.darken(0.2)};
+      color: ${theme.baseBrighter};
+    }
+  `),
+  silver: cmz(
+    baseStyles.root, `
+    & {
+      background-color: ${theme.lineSilver2};
+      border-color: ${theme.lineSilver2};
+      color: ${theme.iconGray};
+    }
+
+    &.outlined {
+      color: ${theme.iconGray}
+    }
+
+    &:not(.raised):hover {
+      background-color: ${theme.lineSilver2.darken(0.2)};
+      border-color: ${theme.lineSilver2.darken(0.2)};
       color: ${theme.baseBrighter};
     }
   `)
@@ -127,7 +147,17 @@ const extraStyles = {
     display: block
     margin: 10px auto
     width: 200px
-  `)
+  `),
+
+  rounded: cmz(`
+    border-radius: 4px
+  `),
+
+  raised: cmz(`
+    &:hover {
+      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    }
+`)
 }
 
 class Button extends PureComponent<Props> {
@@ -138,6 +168,8 @@ class Button extends PureComponent<Props> {
     size: 'normal',
     outlined: false,
     disabled: false,
+    rounded: false,
+    raised: false,
     block: false
   }
 
@@ -148,6 +180,8 @@ class Button extends PureComponent<Props> {
       color,
       outlined,
       disabled,
+      rounded,
+      raised,
       block,
       component: CustomComponent,
       children,
@@ -159,6 +193,10 @@ class Button extends PureComponent<Props> {
     const extraClassName = [
       outlined && extraStyles.outlined,
       outlined && 'outlined',
+      rounded && extraStyles.rounded,
+      rounded && 'rounded',
+      raised && extraStyles.raised,
+      raised && 'raised',
       block && extraStyles.block,
       disabled && extraStyles.disabled
     ].filter(Boolean).join(' ')

--- a/src/components/ui/Button.md
+++ b/src/components/ui/Button.md
@@ -6,6 +6,12 @@ default red state
 <Button>Normal state with default color</Button>
 ```
 
+silver state
+
+```js
+<Button color={'silver'}>Normal state with silver color</Button>
+```
+
 monochrome state
 
 ```js
@@ -46,6 +52,18 @@ disabled
 <Button disabled>Disabled state</Button>
 ```
 
+rounded default
+
+```js
+<Button rounded>Rounded default state</Button>
+```
+
+raised default
+
+```js
+<Button raised>Raised default state</Button>
+```
+
 outlined default
 
 ```js
@@ -58,31 +76,30 @@ outlined monochrome
 <Button outlined color={'monochrome'}>Outlined monochrome state</Button>
 ```
 
-silver
-
-```js
-<Button color={'silver'}>Outlined silver state</Button>
-```
-
-
-outline silver
+outlined silver
 
 ```js
 <Button outlined color={'silver'}>Outlined silver state</Button>
 ```
 
-outlined rounded raised silver
-
-```js
-<Button outlined rounded raised color={'silver'}>Outlined silver state</Button>
-```
-
-
-
 button generated with custom element (&lt;a&gt;)
 
 ```js
 <Button component='a' color={'monochrome'}>custom default button state</Button>
+```
+
+### Use Cases
+
+skill tag
+
+```js
+<Button outlined rounded raised color={'silver'}>Androind</Button>
+```
+
+selected skill tag
+
+```js
+<Button selected outlined rounded raised color={'silver'}>Android</Button>
 ```
 
 Missing props (does component explode?):

--- a/src/components/ui/Button.md
+++ b/src/components/ui/Button.md
@@ -58,6 +58,27 @@ outlined monochrome
 <Button outlined color={'monochrome'}>Outlined monochrome state</Button>
 ```
 
+silver
+
+```js
+<Button color={'silver'}>Outlined silver state</Button>
+```
+
+
+outline silver
+
+```js
+<Button outlined color={'silver'}>Outlined silver state</Button>
+```
+
+outlined rounded raised silver
+
+```js
+<Button outlined rounded raised color={'silver'}>Outlined silver state</Button>
+```
+
+
+
 button generated with custom element (&lt;a&gt;)
 
 ```js

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -20,6 +20,7 @@ function wrap (theme) {
  */
 const palette = {
   white: '#FFF',
+  black: '#000',
   haiti: '#130E2E',
   fern: '#5CB85C',
   radicalRed: '#F63954',
@@ -40,6 +41,7 @@ const palette = {
 export default wrap({
   baseBrighter: palette.white,
   baseDarker: palette.haiti,
+  baseDark: palette.black,
   baseRed: palette.radicalRed,
   baseLightRed: palette.wePeep,
   baseGreen: palette.fern,


### PR DESCRIPTION
Fixes #135 

## Description

Added silver color option
Added raised option to raise the color on hover instead of changing the background
added an option to make buttons rounded

![move](https://user-images.githubusercontent.com/4315829/39787721-c5c259a6-52f4-11e8-8db2-687bc04c496a.gif)

## Checklist

**Before submitting a pull request,** please make sure the following is done:

<!-- Remove items that do not apply. Just tick completed items in UI -->
- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (initially it's mostly `ready for review`)
- [x] set `ready for review` label for respective issue as well
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run typecheck`)
- [x] **manually tested the app** by running it in the browser and checked nothing is broken and operates as expected!

## Steps to Test or Reproduce

See the button silver options in the library
