### PR TITLE
Normalize video player props to match video tag attrs

### DIFF
--- a/.snapguidist/__snapshots__/VideoPlayer-1.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-1.snap
@@ -1,8 +1,12 @@
 exports[`VideoPlayer-1 1`] = `
 <video
-  className="AutoUI_ui_VideoPlayer-20"
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
   controls={true}
-  poster="">
+  loop={false}
+  muted={false}
+  poster=""
+  preload="auto">
   <source
     src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
   Video cannot be played in this browser.

--- a/.snapguidist/__snapshots__/VideoPlayer-11.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-11.snap
@@ -1,9 +1,14 @@
 exports[`VideoPlayer-11 1`] = `
 <video
-  className="AutoUI_ui_VideoPlayer-20"
-  controls={true}
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
+  controls={false}
+  height={360}
+  loop={false}
+  muted={false}
   poster=""
-  width={560}>
+  preload="auto"
+  width={640}>
   <source
     src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
   Video cannot be played in this browser.

--- a/.snapguidist/__snapshots__/VideoPlayer-13.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-13.snap
@@ -1,7 +1,16 @@
 exports[`VideoPlayer-13 1`] = `
-<iframe
-  className="AutoUI_ui_VideoPlayer-16"
-  height={315}
-  src="https://www.youtube.com/embed/R6NUFRNEai4?showinfo=0"
-  width={560} />
+<video
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
+  controls={true}
+  height={360}
+  loop={false}
+  muted={false}
+  poster=""
+  preload="auto"
+  width={640}>
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  Video cannot be played in this browser.
+</video>
 `;

--- a/.snapguidist/__snapshots__/VideoPlayer-17.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-17.snap
@@ -1,9 +1,15 @@
 exports[`VideoPlayer-17 1`] = `
 <video
-  className="AutoUI_ui_VideoPlayer-20"
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
   controls={true}
-  poster="">
-  <source />
+  height={360}
+  loop={false}
+  muted={false}
+  poster=""
+  preload="auto">
+  <source
+    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
   Video cannot be played in this browser.
 </video>
 `;

--- a/.snapguidist/__snapshots__/VideoPlayer-19.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-19.snap
@@ -1,0 +1,7 @@
+exports[`VideoPlayer-19 1`] = `
+<iframe
+  className="AutoUI_ui_VideoPlayer-20"
+  height={360}
+  src="https://www.youtube.com/embed/R6NUFRNEai4?showinfo=0&autoplay=0&controls=1&loop=0&muted=0&poster=&preload=auto"
+  width={640} />
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-21.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-21.snap
@@ -1,0 +1,7 @@
+exports[`VideoPlayer-21 1`] = `
+<iframe
+  className="AutoUI_ui_VideoPlayer-20"
+  height={360}
+  src="https://www.youtube.com/embed/R6NUFRNEai4?showinfo=0&autoplay=0&controls=0&loop=0&muted=0&poster=&preload=auto"
+  width={640} />
+`;

--- a/.snapguidist/__snapshots__/VideoPlayer-23.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-23.snap
@@ -1,4 +1,4 @@
-exports[`VideoPlayer-15 1`] = `
+exports[`VideoPlayer-23 1`] = `
 <video
   autoPlay={false}
   className="AutoUI_ui_VideoPlayer-24"
@@ -6,10 +6,8 @@ exports[`VideoPlayer-15 1`] = `
   loop={false}
   muted={false}
   poster=""
-  preload="auto"
-  width={640}>
-  <source
-    src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
+  preload="auto">
+  <source />
   Video cannot be played in this browser.
 </video>
 `;

--- a/.snapguidist/__snapshots__/VideoPlayer-3.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-3.snap
@@ -1,9 +1,14 @@
 exports[`VideoPlayer-3 1`] = `
 <video
-  className="AutoUI_ui_VideoPlayer-20"
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
   controls={true}
-  poster="http://www.hdfbcover.com/randomcovers/covers/never-stop-dreaming-quote-fb-cover.jpg"
-  width={560}>
+  height={360}
+  loop={true}
+  muted={false}
+  poster=""
+  preload="auto"
+  width={640}>
   <source
     src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
   Video cannot be played in this browser.

--- a/.snapguidist/__snapshots__/VideoPlayer-5.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-5.snap
@@ -1,10 +1,14 @@
 exports[`VideoPlayer-5 1`] = `
 <video
-  className="AutoUI_ui_VideoPlayer-20"
-  controls={false}
-  height={320}
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
+  controls={true}
+  height={360}
+  loop={false}
+  muted={true}
   poster=""
-  width={560}>
+  preload="auto"
+  width={640}>
   <source
     src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
   Video cannot be played in this browser.

--- a/.snapguidist/__snapshots__/VideoPlayer-7.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-7.snap
@@ -1,10 +1,14 @@
 exports[`VideoPlayer-7 1`] = `
 <video
-  className="AutoUI_ui_VideoPlayer-20"
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
   controls={true}
-  height={320}
-  poster=""
-  width={540}>
+  height={360}
+  loop={false}
+  muted={false}
+  poster="http://www.hdfbcover.com/randomcovers/covers/never-stop-dreaming-quote-fb-cover.jpg"
+  preload="auto"
+  width={640}>
   <source
     src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
   Video cannot be played in this browser.

--- a/.snapguidist/__snapshots__/VideoPlayer-9.snap
+++ b/.snapguidist/__snapshots__/VideoPlayer-9.snap
@@ -1,9 +1,14 @@
 exports[`VideoPlayer-9 1`] = `
 <video
-  className="AutoUI_ui_VideoPlayer-20"
+  autoPlay={false}
+  className="AutoUI_ui_VideoPlayer-24"
   controls={true}
-  height={320}
-  poster="">
+  height={360}
+  loop={false}
+  muted={false}
+  poster=""
+  preload="none"
+  width={640}>
   <source
     src="https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4" />
   Video cannot be played in this browser.

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -22074,6 +22074,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = __webpack_require__(0);
@@ -22090,46 +22092,87 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var cmz = __webpack_require__(1);
 
-var iframeStyles = cmz.named('AutoUI_ui_VideoPlayer-16', /*cmz|*/'\n  border: 0;\n' /*|cmz*/);
+var iframeStyles = cmz.named('AutoUI_ui_VideoPlayer-20', /*cmz|*/'\n  border: 0;\n' /*|cmz*/);
 
-var videoStyles = cmz.named('AutoUI_ui_VideoPlayer-20', /*cmz|*/'\n  text-align: center;\n  margin: 0 auto 20px;\n' /*|cmz*/);
+var videoStyles = cmz.named('AutoUI_ui_VideoPlayer-24', /*cmz|*/'\n  text-align: center;\n  margin: 0 auto 20px;\n' /*|cmz*/);
 
 var VideoPlayer = function (_PureComponent) {
   _inherits(VideoPlayer, _PureComponent);
 
   function VideoPlayer() {
+    var _ref;
+
+    var _temp, _this, _ret;
+
     _classCallCheck(this, VideoPlayer);
 
-    return _possibleConstructorReturn(this, (VideoPlayer.__proto__ || Object.getPrototypeOf(VideoPlayer)).apply(this, arguments));
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = VideoPlayer.__proto__ || Object.getPrototypeOf(VideoPlayer)).call.apply(_ref, [this].concat(args))), _this), _this.getEmbeddedVideoSrc = function () {
+      var _this$props = _this.props,
+          src = _this$props.src,
+          autoPlay = _this$props.autoPlay,
+          showControls = _this$props.showControls,
+          loop = _this$props.loop,
+          muted = _this$props.muted,
+          poster = _this$props.poster,
+          preload = _this$props.preload;
+
+
+      return Object.entries({
+        autoplay: autoPlay,
+        controls: showControls,
+        loop: loop,
+        muted: muted,
+        poster: poster,
+        preload: preload
+      }).reduce(function (result, _ref2) {
+        var _ref3 = _slicedToArray(_ref2, 2),
+            key = _ref3[0],
+            val = _ref3[1];
+
+        var value = typeof val !== 'boolean' ? val : val === true ? 1 : 0;
+
+        return result + '&' + key + '=' + String(value);
+      }, src + '?showinfo=0');
+    }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 
   _createClass(VideoPlayer, [{
     key: 'render',
     value: function render() {
       var _props = this.props,
-          width = _props.width,
-          height = _props.height,
-          poster = _props.poster,
           src = _props.src,
           embedded = _props.embedded,
-          showControls = _props.showControls;
+          width = _props.width,
+          height = _props.height,
+          autoPlay = _props.autoPlay,
+          showControls = _props.showControls,
+          loop = _props.loop,
+          muted = _props.muted,
+          poster = _props.poster,
+          preload = _props.preload;
 
-
-      var embeddedVideoSrc = showControls ? src + '?showinfo=0' : src + '?controls=0&showinfo=0';
 
       return embedded ? _react2.default.createElement('iframe', {
         className: iframeStyles,
+        src: this.getEmbeddedVideoSrc(),
         width: width,
-        height: height,
-        src: embeddedVideoSrc
+        height: height
       }) : _react2.default.createElement(
         'video',
         {
           className: videoStyles,
-          controls: showControls,
           width: width,
           height: height,
-          poster: poster
+          autoPlay: autoPlay,
+          controls: showControls,
+          loop: loop,
+          muted: muted,
+          poster: poster,
+          preload: preload
         },
         _react2.default.createElement('source', { src: src }),
         'Video cannot be played in this browser.'
@@ -22141,9 +22184,13 @@ var VideoPlayer = function (_PureComponent) {
 }(_react.PureComponent);
 
 VideoPlayer.defaultProps = {
-  showControls: true,
   embedded: false,
-  poster: ''
+  autoPlay: false,
+  showControls: true,
+  loop: false,
+  muted: false,
+  poster: '',
+  preload: 'auto'
 };
 exports.default = VideoPlayer;
 

--- a/src/components/ui/VideoPlayer.js
+++ b/src/components/ui/VideoPlayer.js
@@ -14,7 +14,7 @@ type Props = {
   loop?: boolean,
   muted?: boolean,
   poster?: string,
-  preload?: 'auto' | 'metadata' | 'none',
+  preload?: 'auto' | 'metadata' | 'none'
 }
 
 const iframeStyles = cmz(`

--- a/src/components/ui/VideoPlayer.js
+++ b/src/components/ui/VideoPlayer.js
@@ -5,12 +5,16 @@ import React, { PureComponent } from 'react'
 const cmz = require('cmz')
 
 type Props = {
+  src: string,
+  embedded?: boolean,
   width?: number,
   height?: number,
-  poster?: string,
-  embedded?: boolean,
+  autoPlay?: boolean,
   showControls?: boolean,
-  src: string,
+  loop?: boolean,
+  muted?: boolean,
+  poster?: string,
+  preload?: 'auto' | 'metadata' | 'none',
 }
 
 const iframeStyles = cmz(`
@@ -24,39 +28,76 @@ const videoStyles = cmz(`
 
 class VideoPlayer extends PureComponent<Props> {
   static defaultProps = {
-    showControls: true,
     embedded: false,
-    poster: ''
+    autoPlay: false,
+    showControls: true,
+    loop: false,
+    muted: false,
+    poster: '',
+    preload: 'auto'
+  }
+
+  getEmbeddedVideoSrc = () => {
+    const {
+      src,
+      autoPlay,
+      showControls,
+      loop,
+      muted,
+      poster,
+      preload
+    } = this.props
+
+    return Object.entries({
+      autoplay: autoPlay,
+      controls: showControls,
+      loop,
+      muted,
+      poster,
+      preload
+    }).reduce((result, [key, val]) => {
+      const value = typeof val !== 'boolean'
+        ? val
+        : val === true ? 1 : 0
+
+      return `${result}&${key}=${String(value)}`
+    }, `${src}?showinfo=0`)
   }
 
   render () {
     const {
-      width,
-      height,
-      poster,
       src,
       embedded,
-      showControls
+      width,
+      height,
+      autoPlay,
+      showControls,
+      loop,
+      muted,
+      poster,
+      preload
     } = this.props
-
-    const embeddedVideoSrc = showControls ? `${src}?showinfo=0` : `${src}?controls=0&showinfo=0`
 
     return embedded
       ? (
         <iframe
           className={iframeStyles}
+          src={this.getEmbeddedVideoSrc()}
           width={width}
           height={height}
-          src={embeddedVideoSrc}
         />
       )
       : (
         <video
           className={videoStyles}
-          controls={showControls}
           width={width}
           height={height}
+          autoPlay={autoPlay}
+          controls={showControls}
+          loop={loop}
+          muted={muted}
           poster={poster}
+          preload={preload}
         >
           <source src={src} />
           Video cannot be played in this browser.

--- a/src/components/ui/VideoPlayer.md
+++ b/src/components/ui/VideoPlayer.md
@@ -4,13 +4,47 @@ Regular video, source is provided only, video is set to its original sizes:
 <VideoPlayer src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'} />
 ```
 
-Poster set:
+Loop set, custom width and custom height set:
 
 ```js
 <VideoPlayer
   src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
-  width={560}
+  width={640}
+  height={360}
+  loop={true}
+/>
+```
+
+Muted set, custom width and custom height set:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  width={640}
+  height={360}
+  muted={true}
+/>
+```
+
+Poster set, custom width and custom height set:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  width={640}
+  height={360}
   poster={'http://www.hdfbcover.com/randomcovers/covers/never-stop-dreaming-quote-fb-cover.jpg'}
+/>
+```
+
+No preload, custom width and custom height set:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  width={640}
+  height={360}
+  preload={'none'}
 />
 ```
 
@@ -19,8 +53,8 @@ No controls, custom width and custom height set:
 ```js
 <VideoPlayer
   src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
-  width={560}
-  height={320}
+  width={640}
+  height={360}
   showControls={false}
 />
 ```
@@ -30,17 +64,8 @@ Visible controls, custom width and custom height set:
 ```js
 <VideoPlayer
   src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
-  width={540}
-  height={320}
-/>
-```
-
-Visible controls, custom height set / auto width:
-
-```js
-<VideoPlayer
-  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
-  height={320}
+  width={640}
+  height={360}
 />
 ```
 
@@ -49,7 +74,16 @@ Visible controls, custom width set / auto height:
 ```js
 <VideoPlayer
   src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
-  width={560}
+  width={640}
+/>
+```
+
+Visible controls, custom height set / auto width:
+
+```js
+<VideoPlayer
+  src={'https://files.slack.com/files-pri/T0257R0RP-F7SGYKZ5F/refactor.mp4'}
+  height={360}
 />
 ```
 
@@ -59,8 +93,8 @@ Embedded video, visible controls:
 <VideoPlayer
   src={'https://www.youtube.com/embed/R6NUFRNEai4'}
   embedded
-  width={560}
-  height={315}
+  width={640}
+  height={360}
 />
 ```
 
@@ -70,8 +104,8 @@ Embedded video, hidden controls:
 <VideoPlayer
   src={'https://www.youtube.com/embed/R6NUFRNEai4'}
   embedded
-  width={560}
-  height={315}
+  width={640}
+  height={360}
   showControls={false}
 />
 ```


### PR DESCRIPTION
<!--
Thank you for your pull request!

Provide a general summary of your changes in the Title above. Do not include any task numbers.
Use imperative, present tense: "Change" not "Changed" nor "Changes". This will become a correct final merge commit message 😄
The imperative tells someone what merging the PR **will do**, rather than **what you did**.
-->

**Release Type:** *New feature* <!-- Refer to the wiki https://github.com/x-team/auto/wiki/Release-Process#types-of-releases -->
<!--
Basic types are:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->

Fixes x-team/auto#1131

## Description

- Normalizes the video player props to match video tag attrs.

## Checklist

<!-- Remove items that do not apply. Just tick completed items in UI -->
- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (initially it's mostly `[zube]: In Review`)
- [x] set `[zube]: In Review` label for respective issue as well
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run flow`)
- [x] **manually tested the app** by running it in the browser and checked nothing is broken and operates as expected!

## Related PRs

branch | PR
------ | ------
`1131-allow-playback-and-re-record-of-video` | [Auto](https://github.com/x-team/auto/pull/1223)
`1131-allow-playback-and-re-record-of-video` | [Auto API](https://github.com/x-team/auto-api/pull/400)

## Steps to Test or Reproduce

- Navigate to the `VideoPlayer` component section.
- Make sure the props match the `video` attrs.
