### PR TITLE
Fix bug with empty arrays on ApplicantBadge

### DIFF
--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -5243,8 +5243,8 @@ var ApplicantBadge = function (_PureComponent) {
             exclusionFormRender
           )
         ),
-        info && info.length && mapInfosToRender(info),
-        tags && tags.length && mapTagsToRender(tags),
+        info && info.length > 0 && mapInfosToRender(info),
+        tags && tags.length > 0 && mapTagsToRender(tags),
         children && _react2.default.createElement(
           'div',
           { className: cx.children },

--- a/src/components/ui/ApplicantBadge.js
+++ b/src/components/ui/ApplicantBadge.js
@@ -325,8 +325,8 @@ class ApplicantBadge extends PureComponent<Props> {
             </Dropdown>
           )}
         </div>
-        {info && info.length && mapInfosToRender(info)}
-        {tags && tags.length && mapTagsToRender(tags)}
+        {info && info.length > 0 && mapInfosToRender(info)}
+        {tags && tags.length > 0 && mapTagsToRender(tags)}
         {children && (
           <div className={cx.children}>
             {children}


### PR DESCRIPTION
This PR prevents the `0` from appears as content inside ApplicantBadges:

![image](https://user-images.githubusercontent.com/579331/42728314-7e5114bc-87c0-11e8-8d62-4d75abfe1ff5.png)