### PR TITLE
hotfix - missing function call brackets 

### DIFF
--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -5240,7 +5240,7 @@ var ApplicantBadge = function (_PureComponent) {
                 _react2.default.createElement(_SvgIcon2.default, { icon: 'x' })
               )
             },
-            exclusionFormRender
+            exclusionFormRender()
           )
         ),
         info && info.length > 0 && mapInfosToRender(info),

--- a/src/components/ui/ApplicantBadge.js
+++ b/src/components/ui/ApplicantBadge.js
@@ -311,7 +311,7 @@ class ApplicantBadge extends PureComponent<Props> {
           </div>
         )}
         <div className={cx.controls}>
-          {exclusionFormRender && (
+          {/* {exclusionFormRender && (
             <Dropdown
               tooltip
               label={(
@@ -320,8 +320,9 @@ class ApplicantBadge extends PureComponent<Props> {
                 </span>
               )}
             >
-              {exclusionFormRender}
-            </Dropdown>
+              
+            </Dropdown> */}
+            {exclusionFormRender}
           )}
         </div>
         {info && info.length > 0 && mapInfosToRender(info)}

--- a/src/components/ui/ApplicantBadge.js
+++ b/src/components/ui/ApplicantBadge.js
@@ -311,7 +311,7 @@ class ApplicantBadge extends PureComponent<Props> {
           </div>
         )}
         <div className={cx.controls}>
-          {/* {exclusionFormRender && (
+          {exclusionFormRender && (
             <Dropdown
               tooltip
               label={(
@@ -320,9 +320,8 @@ class ApplicantBadge extends PureComponent<Props> {
                 </span>
               )}
             >
-              
-            </Dropdown> */}
-            {exclusionFormRender}
+              {exclusionFormRender()}
+            </Dropdown>
           )}
         </div>
         {info && info.length > 0 && mapInfosToRender(info)}

--- a/src/components/ui/ApplicantBadge.md
+++ b/src/components/ui/ApplicantBadge.md
@@ -31,7 +31,7 @@ Basic card:
     'Webpack'
   ]}
   onClick={id => console.log('Applicant selected: ' + id)}
-  exclusionFormRender={<form>A list of inputs with a submit button</form>}
+  exclusionFormRender={() => <form>A list of inputs with a submit button</form>}
 />
 ```
 
@@ -75,7 +75,7 @@ Active card:
     'Webpack'
   ]}
   onClick={id => console.log('Applicant selected: ' + id)}
-  exclusionFormRender={<form>A list of inputs with a submit button</form>}
+  exclusionFormRender={() => <form>A list of inputs with a submit button</form>}
 />
 ```
 
@@ -127,7 +127,7 @@ Basic tabular:
     'Webpack'
   ]}
   onClick={id => console.log('Applicant selected: ' + id)}
-  exclusionFormRender={<form>A list of inputs with a submit button</form>}
+  exclusionFormRender={() => <form>A list of inputs with a submit button</form>}
 />
 ```
 


### PR DESCRIPTION
This is an hotfix that affects https://github.com/x-team/auto/issues/1293.

I was trying to render my custom component inside `ApplicantBadge` and it was not working because of the missing brackets.

before:
![screenshot from 2018-07-17 17-47-34](https://user-images.githubusercontent.com/119362/42834771-e07a4bd4-89f7-11e8-9d72-365ecc25e327.png)

after:
![screenshot from 2018-07-17 19-23-01](https://user-images.githubusercontent.com/119362/42834770-e05ca4da-89f7-11e8-8742-9a043fce4c9d.png)


