### PR TITLE
Update attach files style when in preview mode

### DIFF
--- a/.snapguidist/__snapshots__/AttachFiles-1.snap
+++ b/.snapguidist/__snapshots__/AttachFiles-1.snap
@@ -1,14 +1,15 @@
 exports[`AttachFiles-1 1`] = `
 <div>
   <input
-    className="AutoUI_ui_AttachFiles-83"
+    accept=""
+    className="AutoUI_ui_AttachFiles-87"
     type="file" />
   <button
     className=" AutoUI_ui_Button-70 AutoUI_ui_Button-32 AutoUI_ui_Button-121 AutoUI_ui_Button-140 outlined">
     <span
       className="AutoUI_ui_Button-46 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
       <span
-        className="AutoUI_ui_AttachFiles-79">
+        className="AutoUI_ui_AttachFiles-83">
         Attach a file
       </span>
     </span>
@@ -29,7 +30,7 @@ exports[`AttachFiles-1 1`] = `
         filename-01.zip
       </a>
       <div
-        className="AutoUI_ui_AttachFiles-64"
+        className="AutoUI_ui_AttachFiles-68"
         title="Delete \"filename-01.zip\" file">
         <svg
           height="18px"
@@ -102,7 +103,7 @@ exports[`AttachFiles-1 1`] = `
         filename-02.zip
       </a>
       <div
-        className="AutoUI_ui_AttachFiles-64"
+        className="AutoUI_ui_AttachFiles-68"
         title="Delete \"filename-02.zip\" file">
         <svg
           height="18px"
@@ -183,7 +184,7 @@ exports[`AttachFiles-1 1`] = `
         filename-03.zip
       </a>
       <div
-        className="AutoUI_ui_AttachFiles-64"
+        className="AutoUI_ui_AttachFiles-68"
         title="Cancel \"filename-03.zip\" upload">
         <svg
           height="14px"
@@ -221,7 +222,7 @@ exports[`AttachFiles-1 1`] = `
         </svg>
       </div>
       <div
-        className="AutoUI_ui_AttachFiles-69"
+        className="AutoUI_ui_AttachFiles-73"
         style={
           Object {
             "width": "30%",
@@ -250,7 +251,7 @@ exports[`AttachFiles-1 1`] = `
         filename-04.zip
       </a>
       <div
-        className="AutoUI_ui_AttachFiles-64"
+        className="AutoUI_ui_AttachFiles-68"
         title="Cancel \"filename-04.zip\" upload">
         <svg
           height="14px"
@@ -288,7 +289,7 @@ exports[`AttachFiles-1 1`] = `
         </svg>
       </div>
       <div
-        className="AutoUI_ui_AttachFiles-69"
+        className="AutoUI_ui_AttachFiles-73"
         style={
           Object {
             "width": "90%",

--- a/.snapguidist/__snapshots__/AttachFiles-3.snap
+++ b/.snapguidist/__snapshots__/AttachFiles-3.snap
@@ -1,17 +1,337 @@
 exports[`AttachFiles-3 1`] = `
 <div>
   <input
-    className="AutoUI_ui_AttachFiles-83"
+    accept=""
+    className="AutoUI_ui_AttachFiles-87"
     type="file" />
   <button
     className=" AutoUI_ui_Button-70 AutoUI_ui_Button-32 AutoUI_ui_Button-121 AutoUI_ui_Button-140 outlined">
     <span
       className="AutoUI_ui_Button-46 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
       <span
-        className="AutoUI_ui_AttachFiles-79">
+        className="AutoUI_ui_AttachFiles-83">
         Attach a file
       </span>
     </span>
   </button>
+  <div
+    className="AutoUI_ui_AttachFiles-34">
+    <div
+      className="AutoUI_ui_AttachFiles-38"
+      style={
+        Object {
+          "borderBottomColor": "transparent",
+        }
+      }>
+      <a
+        className="AutoUI_ui_AttachFiles-47 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+        target="_blank">
+        filename-01.zip
+      </a>
+      <div
+        className="AutoUI_ui_AttachFiles-68"
+        title="Delete \"filename-01.zip\" file">
+        <svg
+          height="18px"
+          viewBox="0 0 15 18"
+          width="15px">
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1">
+            <g
+              fill={
+                Object {
+                  "color": Array [
+                    178,
+                    182,
+                    188,
+                  ],
+                  "model": "rgb",
+                  "valpha": 1,
+                }
+              }
+              transform="translate(-1272.000000, -1013.000000)">
+              <g
+                transform="translate(1272.000000, 1013.000000)">
+                <rect
+                  height="2"
+                  width="15"
+                  x="0"
+                  y="3" />
+                <rect
+                  height="2"
+                  width="11"
+                  x="2"
+                  y="16" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="2"
+                  y="5" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="11"
+                  y="5" />
+                <rect
+                  height="2"
+                  width="7"
+                  x="4"
+                  y="0" />
+                <path
+                  d="M8.8890873,10.4748737 L9.94974747,11.5355339 L8.53553391,12.9497475 L7.47487373,11.8890873 L6.41421356,12.9497475 L5,11.5355339 L6.06066017,10.4748737 L5,9.41421356 L6.41421356,8 L7.47487373,9.06066017 L8.53553391,8 L9.94974747,9.41421356 L8.8890873,10.4748737 Z" />
+              </g>
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        className="AutoUI_ui_AttachFiles-73"
+        style={
+          Object {
+            "width": "0%",
+          }
+        } />
+    </div>
+    <div
+      className="AutoUI_ui_AttachFiles-38"
+      style={
+        Object {
+          "borderBottomColor": "transparent",
+        }
+      }>
+      <a
+        className="AutoUI_ui_AttachFiles-47 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+        target="_blank">
+        filename-02.zip
+      </a>
+      <div
+        className="AutoUI_ui_AttachFiles-68"
+        title="Delete \"filename-02.zip\" file">
+        <svg
+          height="18px"
+          viewBox="0 0 15 18"
+          width="15px">
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1">
+            <g
+              fill={
+                Object {
+                  "color": Array [
+                    178,
+                    182,
+                    188,
+                  ],
+                  "model": "rgb",
+                  "valpha": 1,
+                }
+              }
+              transform="translate(-1272.000000, -1013.000000)">
+              <g
+                transform="translate(1272.000000, 1013.000000)">
+                <rect
+                  height="2"
+                  width="15"
+                  x="0"
+                  y="3" />
+                <rect
+                  height="2"
+                  width="11"
+                  x="2"
+                  y="16" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="2"
+                  y="5" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="11"
+                  y="5" />
+                <rect
+                  height="2"
+                  width="7"
+                  x="4"
+                  y="0" />
+                <path
+                  d="M8.8890873,10.4748737 L9.94974747,11.5355339 L8.53553391,12.9497475 L7.47487373,11.8890873 L6.41421356,12.9497475 L5,11.5355339 L6.06066017,10.4748737 L5,9.41421356 L6.41421356,8 L7.47487373,9.06066017 L8.53553391,8 L9.94974747,9.41421356 L8.8890873,10.4748737 Z" />
+              </g>
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        className="AutoUI_ui_AttachFiles-73"
+        style={
+          Object {
+            "width": "0%",
+          }
+        } />
+    </div>
+    <div
+      className="AutoUI_ui_AttachFiles-38"
+      style={
+        Object {
+          "borderBottomColor": "transparent",
+        }
+      }>
+      <a
+        className="AutoUI_ui_AttachFiles-47 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+        target="_blank">
+        filename-03.zip
+      </a>
+      <div
+        className="AutoUI_ui_AttachFiles-68"
+        title="Delete \"filename-03.zip\" file">
+        <svg
+          height="18px"
+          viewBox="0 0 15 18"
+          width="15px">
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1">
+            <g
+              fill={
+                Object {
+                  "color": Array [
+                    178,
+                    182,
+                    188,
+                  ],
+                  "model": "rgb",
+                  "valpha": 1,
+                }
+              }
+              transform="translate(-1272.000000, -1013.000000)">
+              <g
+                transform="translate(1272.000000, 1013.000000)">
+                <rect
+                  height="2"
+                  width="15"
+                  x="0"
+                  y="3" />
+                <rect
+                  height="2"
+                  width="11"
+                  x="2"
+                  y="16" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="2"
+                  y="5" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="11"
+                  y="5" />
+                <rect
+                  height="2"
+                  width="7"
+                  x="4"
+                  y="0" />
+                <path
+                  d="M8.8890873,10.4748737 L9.94974747,11.5355339 L8.53553391,12.9497475 L7.47487373,11.8890873 L6.41421356,12.9497475 L5,11.5355339 L6.06066017,10.4748737 L5,9.41421356 L6.41421356,8 L7.47487373,9.06066017 L8.53553391,8 L9.94974747,9.41421356 L8.8890873,10.4748737 Z" />
+              </g>
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        className="AutoUI_ui_AttachFiles-73"
+        style={
+          Object {
+            "width": "0%",
+          }
+        } />
+    </div>
+    <div
+      className="AutoUI_ui_AttachFiles-38"
+      style={
+        Object {
+          "borderBottomColor": "transparent",
+        }
+      }>
+      <a
+        className="AutoUI_ui_AttachFiles-47 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+        target="_blank">
+        filename-04.zip
+      </a>
+      <div
+        className="AutoUI_ui_AttachFiles-68"
+        title="Delete \"filename-04.zip\" file">
+        <svg
+          height="18px"
+          viewBox="0 0 15 18"
+          width="15px">
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1">
+            <g
+              fill={
+                Object {
+                  "color": Array [
+                    178,
+                    182,
+                    188,
+                  ],
+                  "model": "rgb",
+                  "valpha": 1,
+                }
+              }
+              transform="translate(-1272.000000, -1013.000000)">
+              <g
+                transform="translate(1272.000000, 1013.000000)">
+                <rect
+                  height="2"
+                  width="15"
+                  x="0"
+                  y="3" />
+                <rect
+                  height="2"
+                  width="11"
+                  x="2"
+                  y="16" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="2"
+                  y="5" />
+                <rect
+                  height="12"
+                  width="2"
+                  x="11"
+                  y="5" />
+                <rect
+                  height="2"
+                  width="7"
+                  x="4"
+                  y="0" />
+                <path
+                  d="M8.8890873,10.4748737 L9.94974747,11.5355339 L8.53553391,12.9497475 L7.47487373,11.8890873 L6.41421356,12.9497475 L5,11.5355339 L6.06066017,10.4748737 L5,9.41421356 L6.41421356,8 L7.47487373,9.06066017 L8.53553391,8 L9.94974747,9.41421356 L8.8890873,10.4748737 Z" />
+              </g>
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        className="AutoUI_ui_AttachFiles-73"
+        style={
+          Object {
+            "width": "0%",
+          }
+        } />
+    </div>
+  </div>
 </div>
 `;

--- a/.snapguidist/__snapshots__/AttachFiles-5.snap
+++ b/.snapguidist/__snapshots__/AttachFiles-5.snap
@@ -1,0 +1,18 @@
+exports[`AttachFiles-5 1`] = `
+<div>
+  <input
+    accept=""
+    className="AutoUI_ui_AttachFiles-87"
+    type="file" />
+  <button
+    className=" AutoUI_ui_Button-70 AutoUI_ui_Button-32 AutoUI_ui_Button-121 AutoUI_ui_Button-140 outlined">
+    <span
+      className="AutoUI_ui_Button-46 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
+      <span
+        className="AutoUI_ui_AttachFiles-83">
+        Attach a file
+      </span>
+    </span>
+  </button>
+</div>
+`;

--- a/.snapguidist/__snapshots__/Dropdown-3.snap
+++ b/.snapguidist/__snapshots__/Dropdown-3.snap
@@ -106,7 +106,6 @@ exports[`Dropdown-3 1`] = `
                   aria-labelledby="label-search"
                   autoComplete="off"
                   className="AutoUI_typo-181 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-87 AutoUI_ui_SelectBox-79"
-                  disabled={false}
                   id="search"
                   name="search"
                   placeholder="Search"
@@ -124,42 +123,42 @@ exports[`Dropdown-3 1`] = `
                 }
               }>
               <li
-                className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                 <span
                   className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                   item-1
                 </span>
               </li>
               <li
-                className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                 <span
                   className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                   item-2
                 </span>
               </li>
               <li
-                className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                 <span
                   className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                   item-3
                 </span>
               </li>
               <li
-                className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                 <span
                   className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                   item-4
                 </span>
               </li>
               <li
-                className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                 <span
                   className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                   item-5
                 </span>
               </li>
               <li
-                className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                 <span
                   className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                   item-6

--- a/.snapguidist/__snapshots__/Dropdown-7.snap
+++ b/.snapguidist/__snapshots__/Dropdown-7.snap
@@ -254,7 +254,6 @@ exports[`Dropdown-7 1`] = `
                       aria-labelledby="label-search"
                       autoComplete="off"
                       className="AutoUI_typo-181 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-87 AutoUI_ui_SelectBox-79"
-                      disabled={false}
                       id="search"
                       name="search"
                       placeholder="Search"
@@ -278,35 +277,35 @@ exports[`Dropdown-7 1`] = `
                     }
                   }>
                   <li
-                    className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                    className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                     <span
                       className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                       registered
                     </span>
                   </li>
                   <li
-                    className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                    className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                     <span
                       className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                       portfolio-building
                     </span>
                   </li>
                   <li
-                    className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                    className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                     <span
                       className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                       portfolio-review
                     </span>
                   </li>
                   <li
-                    className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                    className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                     <span
                       className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                       social-media-screen
                     </span>
                   </li>
                   <li
-                    className="AutoUI_ui_SelectBox-148 AutoUI_ui_SelectBox-161 ">
+                    className="AutoUI_ui_SelectBox-148 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SelectBox-165   ">
                     <span
                       className="AutoUI_ui_SelectBox-121 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
                       react-shortlist

--- a/.snapguidist/__snapshots__/Note-3.snap
+++ b/.snapguidist/__snapshots__/Note-3.snap
@@ -21,7 +21,7 @@ exports[`Note-3 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      02 Aug 18
+      03 Aug 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/Note-3.snap
+++ b/.snapguidist/__snapshots__/Note-3.snap
@@ -21,7 +21,7 @@ exports[`Note-3 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      6 m ago
+      02 Aug 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/Note-5.snap
+++ b/.snapguidist/__snapshots__/Note-5.snap
@@ -9,7 +9,7 @@ exports[`Note-5 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      2 h ago
+      02 Aug 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/Note-5.snap
+++ b/.snapguidist/__snapshots__/Note-5.snap
@@ -9,7 +9,7 @@ exports[`Note-5 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      02 Aug 18
+      03 Aug 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -8621,15 +8621,15 @@ var FilesList = _elem2.default.div(cmz.named('AutoUI_ui_AttachFiles-34', /*cmz|*
 
 var FileItem = _elem2.default.div(cmz.named('AutoUI_ui_AttachFiles-38', '\n  position: relative\n  display: flex\n  align-items: start\n  height: 20px\n  margin-bottom: 20px\n  border-bottom: 2px solid ' + _theme2.default.baseSilver + '\n'));
 
-var FileName = _elem2.default.a(cmz.named('AutoUI_ui_AttachFiles-47', _typo2.default.baseText, '\n    & {\n      width: 100%\n      font-size: 16px\n      line-height: 1\n      text-align: left\n      text-decoration: none\n    }\n\n    &:hover {\n      color: ' + _theme2.default.baseRed + '\n    }\n  '));
+var FileName = _elem2.default.a(cmz.named('AutoUI_ui_AttachFiles-47', _typo2.default.baseText, '\n    & {\n      width: 100%\n      font-size: 16px\n      line-height: 1\n      text-align: left\n      text-decoration: none\n    }\n\n    &:hover {\n      color: ' + _theme2.default.typoParagraph + '\n    }\n\n    &[href]:hover {\n      color: ' + _theme2.default.baseRed + '\n    }\n  '));
 
-var FileAction = _elem2.default.div(cmz.named('AutoUI_ui_AttachFiles-64', /*cmz|*/'\n  cursor: pointer\n  line-height: normal\n' /*|cmz*/));
+var FileAction = _elem2.default.div(cmz.named('AutoUI_ui_AttachFiles-68', /*cmz|*/'\n  cursor: pointer\n  line-height: normal\n' /*|cmz*/));
 
-var FileProgress = _elem2.default.div(cmz.named('AutoUI_ui_AttachFiles-69', '\n  position: absolute\n  bottom: -2px\n  display: block\n  height: 2px\n  width: 0\n  background-color: ' + _theme2.default.baseRed + '\n  transition: width 0.5s\n'));
+var FileProgress = _elem2.default.div(cmz.named('AutoUI_ui_AttachFiles-73', '\n  position: absolute\n  bottom: -2px\n  display: block\n  height: 2px\n  width: 0\n  background-color: ' + _theme2.default.baseRed + '\n  transition: width 0.5s\n'));
 
-var ButtonLabel = _elem2.default.span(cmz.named('AutoUI_ui_AttachFiles-79', /*cmz|*/'\n  padding: 0 20px\n' /*|cmz*/));
+var ButtonLabel = _elem2.default.span(cmz.named('AutoUI_ui_AttachFiles-83', /*cmz|*/'\n  padding: 0 20px\n' /*|cmz*/));
 
-var HiddenInput = _elem2.default.input(cmz.named('AutoUI_ui_AttachFiles-83', /*cmz|*/'\n  width: 0.1px\n  height: 0.1px\n  opacity: 0\n  overflow: hidden\n  position: absolute\n  zIndex: -1\n' /*|cmz*/));
+var HiddenInput = _elem2.default.input(cmz.named('AutoUI_ui_AttachFiles-87', /*cmz|*/'\n  width: 0.1px\n  height: 0.1px\n  opacity: 0\n  overflow: hidden\n  position: absolute\n  zIndex: -1\n' /*|cmz*/));
 
 var AttachFiles = function (_PureComponent) {
   _inherits(AttachFiles, _PureComponent);
@@ -8658,9 +8658,9 @@ var AttachFiles = function (_PureComponent) {
       var _props = this.props,
           files = _props.files,
           acceptedTypes = _props.acceptedTypes,
+          onFileUpload = _props.onFileUpload,
           onCancel = _props.onCancel,
-          onDelete = _props.onDelete,
-          onFileUpload = _props.onFileUpload;
+          onDelete = _props.onDelete;
 
 
       var renderButton = function renderButton(file) {
@@ -8698,7 +8698,7 @@ var AttachFiles = function (_PureComponent) {
           return FileItem({
             key: file.id || file.filename,
             style: {
-              borderBottomColor: file.progress !== 100 ? _theme2.default.baseSilver : 'transparent'
+              borderBottomColor: file.progress && file.progress !== 100 ? _theme2.default.baseSilver : 'transparent'
             }
           }, FileName({ href: file.path, target: '_blank' }, file.filename), renderButton(file), renderProgress(file.progress));
         }));
@@ -8724,9 +8724,10 @@ var AttachFiles = function (_PureComponent) {
 
 AttachFiles.defaultProps = {
   files: [],
+  acceptedTypes: '',
+  onFileUpload: function onFileUpload() {},
   onCancel: function onCancel() {},
-  onDelete: function onDelete() {},
-  onFileUpload: function onFileUpload() {}
+  onDelete: function onDelete() {}
 };
 exports.default = AttachFiles;
 

--- a/src/components/ui/AttachFiles.js
+++ b/src/components/ui/AttachFiles.js
@@ -13,10 +13,10 @@ import elem from '../../utils/elem'
 const cmz = require('cmz')
 
 type File = {
-  filename: string,
-  path: string,
-  progress: number,
   id?: number | string,
+  filename: string,
+  path?: string,
+  progress?: number
 }
 
 type Files = Array<File>
@@ -24,9 +24,9 @@ type Files = Array<File>
 type Props = {
   files: Files,
   acceptedTypes: string,
+  onFileUpload: Function,
   onCancel: Function,
-  onDelete: Function,
-  onFileUpload: Function
+  onDelete: Function
 }
 
 const Root = elem.div()
@@ -56,6 +56,10 @@ const FileName = elem.a(cmz(
     }
 
     &:hover {
+      color: ${theme.typoParagraph}
+    }
+
+    &[href]:hover {
       color: ${theme.baseRed}
     }
   `
@@ -94,9 +98,10 @@ class AttachFiles extends PureComponent<Props> {
 
   static defaultProps = {
     files: [],
+    acceptedTypes: '',
+    onFileUpload: () => {},
     onCancel: () => {},
-    onDelete: () => {},
-    onFileUpload: () => {}
+    onDelete: () => {}
   }
 
   triggerFileSelection = () => {
@@ -107,9 +112,9 @@ class AttachFiles extends PureComponent<Props> {
     const {
       files,
       acceptedTypes,
+      onFileUpload,
       onCancel,
-      onDelete,
-      onFileUpload
+      onDelete
     } = this.props
 
     const renderButton = (file: File) => {
@@ -155,7 +160,7 @@ class AttachFiles extends PureComponent<Props> {
                 {
                   key: file.id || file.filename,
                   style: {
-                    borderBottomColor: file.progress !== 100 ? theme.baseSilver : 'transparent'
+                    borderBottomColor: file.progress && file.progress !== 100 ? theme.baseSilver : 'transparent'
                   }
                 },
                 FileName({href: file.path, target: '_blank'}, file.filename),

--- a/src/components/ui/AttachFiles.md
+++ b/src/components/ui/AttachFiles.md
@@ -30,6 +30,30 @@ Multiple files:
 />
 ```
 
+Multiple files (Preview):
+
+```js
+<AttachFiles
+  files={[
+    {
+      filename: 'filename-01.zip'
+    },
+    {
+      filename: 'filename-02.zip'
+    },
+    {
+      filename: 'filename-03.zip'
+    },
+    {
+      filename: 'filename-04.zip'
+    }
+  ]}
+  onUpload={() => console.log('upload new file')}
+  onCancel={(file) => console.log('cancel upload of ' + file)}
+  onDelete={(file) => console.log('delete ' + file)}
+/>
+```
+
 None files (no props):
 
 ```js


### PR DESCRIPTION
<!--
Thank you for your pull request!

Provide a general summary of your changes in the Title above. Do not include any task numbers.
Use imperative, present tense: "Change" not "Changed" nor "Changes". This will become a correct final merge commit message 😄
The imperative tells someone what merging the PR **will do**, rather than **what you did**.
-->

**Release Type:** *New feature* <!-- Refer to the wiki https://github.com/x-team/auto/wiki/Release-Process#types-of-releases -->
<!--
Basic types are:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->

Fixes x-team/auto#1372

## Description

- Updates the attach files style when in preview mode.

## Checklist

<!-- Remove items that do not apply. Just tick completed items in UI -->
- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (initially it's mostly `[zube]: In Review`)
- [x] set `[zube]: In Review` label for respective issue as well
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run flow`)
- [x] **manually tested the app** by running it in the browser and checked nothing is broken and operates as expected!

## Related PRs

branch | PR
------ | ------
`1372-notes-bugs-—-do-not-make-initial-note-pre-save` | [Auto](https://github.com/x-team/auto/pull/1418)

## Steps to Test or Reproduce

- Navigate to the `AttachFiles ` component section.
  - Make sure the preview mode works.

## Screenshots

![screen shot 2018-08-03 at 16 31 36](https://user-images.githubusercontent.com/8301142/43664380-c6cf3c4e-973a-11e8-93c5-d5c661a11d0e.png)
