### PR TITLE
 Fix top filters bar spacing

### DIFF
--- a/.snapguidist/__snapshots__/Keywords-1.snap
+++ b/.snapguidist/__snapshots__/Keywords-1.snap
@@ -55,7 +55,7 @@ exports[`Keywords-1 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-27--value">
+      id="react-select-32--value">
       <div
         className="Select-value">
         <span
@@ -66,7 +66,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-0"
+          id="react-select-32--value-0"
           role="option">
           a
           <span
@@ -85,7 +85,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-1"
+          id="react-select-32--value-1"
           role="option">
           simple
           <span
@@ -104,7 +104,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-2"
+          id="react-select-32--value-2"
           role="option">
           string
           <span
@@ -123,7 +123,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-3"
+          id="react-select-32--value-3"
           role="option">
           separated
           <span
@@ -142,7 +142,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-4"
+          id="react-select-32--value-4"
           role="option">
           by
           <span
@@ -161,7 +161,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-5"
+          id="react-select-32--value-5"
           role="option">
           commas
           <span
@@ -180,7 +180,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-6"
+          id="react-select-32--value-6"
           role="option">
           with
           <span
@@ -199,7 +199,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-7"
+          id="react-select-32--value-7"
           role="option">
           operators
           <span
@@ -218,7 +218,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-8"
+          id="react-select-32--value-8"
           role="option">
           AND
           <span
@@ -237,7 +237,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-27--value-9"
+          id="react-select-32--value-9"
           role="option">
           OR
           <span
@@ -254,7 +254,7 @@ exports[`Keywords-1 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-27--value"
+          aria-activedescendant="react-select-32--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Keywords-3.snap
+++ b/.snapguidist/__snapshots__/Keywords-3.snap
@@ -5,7 +5,7 @@ exports[`Keywords-3 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-28--value">
+      id="react-select-33--value">
       <div
         className="Select-placeholder">
         Type keywords
@@ -18,7 +18,7 @@ exports[`Keywords-3 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-28--value"
+          aria-activedescendant="react-select-33--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Note-3.snap
+++ b/.snapguidist/__snapshots__/Note-3.snap
@@ -21,7 +21,7 @@ exports[`Note-3 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      29 Aug 18
+      10 Sep 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/Note-5.snap
+++ b/.snapguidist/__snapshots__/Note-5.snap
@@ -9,7 +9,7 @@ exports[`Note-5 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      29 Aug 18
+      10 Sep 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/NotesFeed-1.snap
+++ b/.snapguidist/__snapshots__/NotesFeed-1.snap
@@ -24,7 +24,7 @@ exports[`NotesFeed-1 1`] = `
         </span>
         <span
           className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-          23 May 18
+          24 May 18
         </span>
         <div
           className="AutoUI_ui_Note-62">
@@ -94,7 +94,7 @@ exports[`NotesFeed-1 1`] = `
         </span>
         <span
           className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-          23 May 18
+          24 May 18
         </span>
         <div
           className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/SearchForm-1.snap
+++ b/.snapguidist/__snapshots__/SearchForm-1.snap
@@ -211,7 +211,7 @@ exports[`SearchForm-1 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-29--value">
+          id="react-select-34--value">
           <div
             className="Select-value">
             <span
@@ -222,7 +222,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-29--value-0"
+              id="react-select-34--value-0"
               role="option">
               a keyword
               <span
@@ -241,7 +241,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-29--value-1"
+              id="react-select-34--value-1"
               role="option">
               OR
               <span
@@ -260,7 +260,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-29--value-2"
+              id="react-select-34--value-2"
               role="option">
               two
               <span
@@ -279,7 +279,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-29--value-3"
+              id="react-select-34--value-3"
               role="option">
               AND
               <span
@@ -298,7 +298,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-29--value-4"
+              id="react-select-34--value-4"
               role="option">
               much more
               <span
@@ -315,7 +315,7 @@ exports[`SearchForm-1 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-29--value"
+              aria-activedescendant="react-select-34--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-3.snap
+++ b/.snapguidist/__snapshots__/SearchForm-3.snap
@@ -211,7 +211,7 @@ exports[`SearchForm-3 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-30--value">
+          id="react-select-35--value">
           <div
             className="Select-value">
             <span
@@ -222,7 +222,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-30--value-0"
+              id="react-select-35--value-0"
               role="option">
               a keyword
               <span
@@ -241,7 +241,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-30--value-1"
+              id="react-select-35--value-1"
               role="option">
               OR
               <span
@@ -260,7 +260,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-30--value-2"
+              id="react-select-35--value-2"
               role="option">
               two
               <span
@@ -279,7 +279,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-30--value-3"
+              id="react-select-35--value-3"
               role="option">
               AND
               <span
@@ -298,7 +298,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-30--value-4"
+              id="react-select-35--value-4"
               role="option">
               much more
               <span
@@ -315,7 +315,7 @@ exports[`SearchForm-3 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-30--value"
+              aria-activedescendant="react-select-35--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -19502,7 +19502,7 @@ var cardTheme = {
 
   formButton: cmz.named('AutoUI_ui_SearchForm-54', /*cmz|*/'\n    display: block\n    width: 100%\n    height: 40px\n    margin-top: 20px\n    padding: 0 24px\n  ' /*|cmz*/),
 
-  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-62', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBright + '\n    padding: 50px 30px 30px\n    box-sizing: border-box\n  ')
+  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-62', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBright + '\n    padding: 10px 30px 30px\n    box-sizing: border-box\n  ')
 };
 
 var tabularTheme = {
@@ -19520,7 +19520,7 @@ var tabularTheme = {
 
   formButton: cmz.named('AutoUI_ui_SearchForm-114', /*cmz|*/'\n    margin: 0 10px\n    height: 58px\n  ' /*|cmz*/),
 
-  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-119', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBrighter + '\n    padding: 50px 30px 30px\n    box-sizing: border-box\n  ')
+  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-119', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBrighter + '\n    padding: 10px 30px 30px\n    box-sizing: border-box\n  ')
 };
 
 var SearchForm = function (_PureComponent) {

--- a/src/components/ui/SearchForm.js
+++ b/src/components/ui/SearchForm.js
@@ -62,7 +62,7 @@ const cardTheme = {
   applicantsStatusFilter: cmz(`
     width: 100%
     background-color: ${theme.baseBright}
-    padding: 50px 30px 30px
+    padding: 10px 30px 30px
     box-sizing: border-box
   `)
 }
@@ -119,7 +119,7 @@ const tabularTheme = {
   applicantsStatusFilter: cmz(`
     width: 100%
     background-color: ${theme.baseBrighter}
-    padding: 50px 30px 30px
+    padding: 10px 30px 30px
     box-sizing: border-box
   `)
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Provide a general summary of your changes in the Title above. Do not include any task numbers.
Use imperative, present tense: "Change" not "Changed" nor "Changes". This will become a correct final merge commit message 😄
The imperative tells someone what merging the PR **will do**, rather than **what you did**.
-->

**Release Type:** *UI improvement* <!-- Refer to the wiki https://github.com/x-team/auto/wiki/Release-Process#types-of-releases -->
<!--
Basic types are:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->

Fixes https://x-team-internal.atlassian.net/browse/XP-2236

## Description

Removes extra space between the Filter button and the List status filters.

## Checklist

**Before submitting a pull request,** please make sure the following is done:

<!-- Remove items that do not apply. Just tick completed items in UI -->
- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (initially it's mostly `[zube]: In Review`)
- [x] set `[zube]: In Review` label for respective issue as well
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run typecheck`)
- [x] **manually tested the app** by running it in the browser and checked nothing is broken and operates as expected!

## Related PRs

List related PRs against other Auto repos if applicable:

branch | PR
------ | ------
xp-2236-filter-form-regression | [Auto](https://github.com/x-team/auto/pull/1522)

## Steps to Test or Reproduce

Load applicants list and see if spacing issues are fixed

## Screenshots

![image](https://user-images.githubusercontent.com/579331/45359551-76d8ae80-b5ff-11e8-80ce-48e6cddae595.png)
