### PR TITLE
Remove show button and rename filter button

### DIFF
--- a/.snapguidist/__snapshots__/Note-3.snap
+++ b/.snapguidist/__snapshots__/Note-3.snap
@@ -21,7 +21,7 @@ exports[`Note-3 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      16 Sep 18
+      17 Sep 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/Note-5.snap
+++ b/.snapguidist/__snapshots__/Note-5.snap
@@ -9,7 +9,7 @@ exports[`Note-5 1`] = `
     </span>
     <span
       className="AutoUI_ui_Note-52 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      16 Sep 18
+      17 Sep 18
     </span>
     <div
       className="AutoUI_ui_Note-62">

--- a/.snapguidist/__snapshots__/SearchForm-1.snap
+++ b/.snapguidist/__snapshots__/SearchForm-1.snap
@@ -4,7 +4,7 @@ exports[`SearchForm-1 1`] = `
   <form
     className="AutoUI_ui_SearchForm-20">
     <div
-      className="AutoUI_ui_SearchForm-35">
+      className="AutoUI_ui_SearchForm-29">
       <div
         className="AutoUI_ui_SelectBox-17"
         style={
@@ -169,17 +169,9 @@ exports[`SearchForm-1 1`] = `
           </div>
         </div>
       </div>
-      <button
-        className="AutoUI_ui_SearchForm-29 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
-        type="button">
-        <span
-          className="AutoUI_ui_Button-48 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
-          Show
-        </span>
-      </button>
     </div>
     <div
-      className="Select AutoUI_ui_Keywords-15 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SearchForm-40 has-value is-clearable is-searchable Select--multi">
+      className="Select AutoUI_ui_Keywords-15 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SearchForm-34 has-value is-clearable is-searchable Select--multi">
       <input
         disabled={false}
         name="keywords"
@@ -362,7 +354,7 @@ exports[`SearchForm-1 1`] = `
       </div>
     </div>
     <div
-      className="AutoUI_ui_SearchForm-48">
+      className="AutoUI_ui_SearchForm-42">
       <div
         className="AutoUI_ui_SelectBox-17"
         style={
@@ -501,16 +493,16 @@ exports[`SearchForm-1 1`] = `
       </div>
     </div>
     <button
-      className="AutoUI_ui_SearchForm-54 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
+      className="AutoUI_ui_SearchForm-48 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
       type="submit">
       <span
         className="AutoUI_ui_Button-48 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
-        Filter
+        Show
       </span>
     </button>
   </form>
   <div
-    className="AutoUI_ui_SearchForm-62">
+    className="AutoUI_ui_SearchForm-56">
     Here it goes ApplicantsStatusFilter component
   </div>
 </div>

--- a/.snapguidist/__snapshots__/SearchForm-3.snap
+++ b/.snapguidist/__snapshots__/SearchForm-3.snap
@@ -1,10 +1,10 @@
 exports[`SearchForm-3 1`] = `
 <div
-  className="AutoUI_ui_SearchForm-71">
+  className="AutoUI_ui_SearchForm-65">
   <form
-    className="AutoUI_ui_SearchForm-79">
+    className="AutoUI_ui_SearchForm-73">
     <div
-      className="AutoUI_ui_SearchForm-93">
+      className="AutoUI_ui_SearchForm-81">
       <div
         className="AutoUI_ui_SelectBox-17"
         style={
@@ -169,17 +169,9 @@ exports[`SearchForm-3 1`] = `
           </div>
         </div>
       </div>
-      <button
-        className="AutoUI_ui_SearchForm-87 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
-        type="button">
-        <span
-          className="AutoUI_ui_Button-48 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
-          Show
-        </span>
-      </button>
     </div>
     <div
-      className="Select AutoUI_ui_Keywords-15 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SearchForm-100 has-value is-clearable is-searchable Select--multi">
+      className="Select AutoUI_ui_Keywords-15 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SearchForm-88 has-value is-clearable is-searchable Select--multi">
       <input
         disabled={false}
         name="keywords"
@@ -362,7 +354,7 @@ exports[`SearchForm-3 1`] = `
       </div>
     </div>
     <div
-      className="AutoUI_ui_SearchForm-108">
+      className="AutoUI_ui_SearchForm-96">
       <div
         className="AutoUI_ui_SelectBox-17"
         style={
@@ -501,16 +493,16 @@ exports[`SearchForm-3 1`] = `
       </div>
     </div>
     <button
-      className="AutoUI_ui_SearchForm-114 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
+      className="AutoUI_ui_SearchForm-102 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
       type="submit">
       <span
         className="AutoUI_ui_Button-48 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
-        Filter
+        Show
       </span>
     </button>
   </form>
   <div
-    className="AutoUI_ui_SearchForm-119">
+    className="AutoUI_ui_SearchForm-107">
     Here it goes ApplicantsStatusFilter component
   </div>
 </div>

--- a/.snapguidist/__snapshots__/SearchForm-5.snap
+++ b/.snapguidist/__snapshots__/SearchForm-5.snap
@@ -4,7 +4,7 @@ exports[`SearchForm-5 1`] = `
   <form
     className="AutoUI_ui_SearchForm-20">
     <div
-      className="AutoUI_ui_SearchForm-35">
+      className="AutoUI_ui_SearchForm-29">
       <div
         className="AutoUI_ui_SelectBox-17"
         style={
@@ -138,17 +138,9 @@ exports[`SearchForm-5 1`] = `
           </div>
         </div>
       </div>
-      <button
-        className="AutoUI_ui_SearchForm-29 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
-        type="button">
-        <span
-          className="AutoUI_ui_Button-48 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
-          Show
-        </span>
-      </button>
     </div>
     <div
-      className="Select AutoUI_ui_Keywords-15 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SearchForm-40 is-clearable is-searchable Select--multi">
+      className="Select AutoUI_ui_Keywords-15 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_SearchForm-34 is-clearable is-searchable Select--multi">
       <div
         className="Select-control">
         <span
@@ -203,7 +195,7 @@ exports[`SearchForm-5 1`] = `
       </div>
     </div>
     <div
-      className="AutoUI_ui_SearchForm-48">
+      className="AutoUI_ui_SearchForm-42">
       <div
         className="AutoUI_ui_SelectBox-17"
         style={
@@ -311,11 +303,11 @@ exports[`SearchForm-5 1`] = `
       </div>
     </div>
     <button
-      className="AutoUI_ui_SearchForm-54 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
+      className="AutoUI_ui_SearchForm-48 AutoUI_ui_Button-72 AutoUI_ui_Button-34 AutoUI_ui_Button-125 AutoUI_ui_Button-176 raised"
       type="submit">
       <span
         className="AutoUI_ui_Button-48 AutoUI_typo-159 AutoUI_typo-53 AutoUI_typo-46">
-        Filter
+        Show
       </span>
     </button>
   </form>

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -19500,35 +19500,31 @@ var cardTheme = {
 
   searchForm: cmz.named('AutoUI_ui_SearchForm-20', /*cmz|*/'\n    & {\n      padding: 30px 50px\n    }\n    &:empty {\n      padding: 0\n    }\n  ' /*|cmz*/),
 
-  listsButton: cmz.named('AutoUI_ui_SearchForm-29', /*cmz|*/'\n    width: 100px\n    height: 58px\n    margin-left: 10px\n  ' /*|cmz*/),
+  selectLists: cmz.named('AutoUI_ui_SearchForm-29', /*cmz|*/'\n    display: flex\n    align-items: center\n  ' /*|cmz*/),
 
-  selectLists: cmz.named('AutoUI_ui_SearchForm-35', /*cmz|*/'\n    display: flex\n    align-items: center\n  ' /*|cmz*/),
+  formKeywords: cmz.named('AutoUI_ui_SearchForm-34', '\n    display: block\n    width: 100%\n    margin: 20px 0 0\n    padding: 20px 0 0\n    border-top: 1px solid ' + _theme2.default.lineSilver4 + '\n  '),
 
-  formKeywords: cmz.named('AutoUI_ui_SearchForm-40', '\n    display: block\n    width: 100%\n    margin: 20px 0 0\n    padding: 20px 0 0\n    border-top: 1px solid ' + _theme2.default.lineSilver4 + '\n  '),
+  selectFields: cmz.named('AutoUI_ui_SearchForm-42', /*cmz|*/'\n    display: inline-block\n    width: 100%\n    margin-top: 20px\n  ' /*|cmz*/),
 
-  selectFields: cmz.named('AutoUI_ui_SearchForm-48', /*cmz|*/'\n    display: inline-block\n    width: 50%\n    margin-top: 20px\n  ' /*|cmz*/),
+  formButton: cmz.named('AutoUI_ui_SearchForm-48', /*cmz|*/'\n    display: block\n    width: 100%\n    height: 40px\n    margin-top: 20px\n    padding: 0 24px\n  ' /*|cmz*/),
 
-  formButton: cmz.named('AutoUI_ui_SearchForm-54', /*cmz|*/'\n    display: block\n    width: 100%\n    height: 40px\n    margin-top: 20px\n    padding: 0 24px\n  ' /*|cmz*/),
-
-  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-62', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBright + '\n    padding: 10px 30px 30px\n    box-sizing: border-box\n  ')
+  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-56', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBright + '\n    padding: 10px 30px 30px\n    box-sizing: border-box\n  ')
 };
 
 var tabularTheme = {
-  searchFormContainer: cmz.named('AutoUI_ui_SearchForm-71', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBright + '\n    display: flex\n    flex-direction: column\n    box-sizing: border-box\n  '),
+  searchFormContainer: cmz.named('AutoUI_ui_SearchForm-65', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBright + '\n    display: flex\n    flex-direction: column\n    box-sizing: border-box\n  '),
 
-  searchForm: cmz.named('AutoUI_ui_SearchForm-79', /*cmz|*/'\n    display: flex\n    flex-shrink: 0\n    width: 100%\n    padding: 50px 30px 30px\n    box-sizing: border-box\n  ' /*|cmz*/),
+  searchForm: cmz.named('AutoUI_ui_SearchForm-73', /*cmz|*/'\n    display: flex\n    flex-shrink: 0\n    width: 100%\n    padding: 50px 30px 30px\n    box-sizing: border-box\n  ' /*|cmz*/),
 
-  listsButton: cmz.named('AutoUI_ui_SearchForm-87', /*cmz|*/'\n    margin: 0 10px 0 20px\n    width: 100px\n    height: 58px\n  ' /*|cmz*/),
+  selectLists: cmz.named('AutoUI_ui_SearchForm-81', /*cmz|*/'\n    width: 420px\n    display: flex\n    flex-shrink: 0\n    align-items: center\n  ' /*|cmz*/),
 
-  selectLists: cmz.named('AutoUI_ui_SearchForm-93', /*cmz|*/'\n    width: 420px\n    display: flex\n    flex-shrink: 0\n    align-items: center\n  ' /*|cmz*/),
+  formKeywords: cmz.named('AutoUI_ui_SearchForm-88', /*cmz|*/'\n    margin: 0 10px\n    min-width: 300px\n    height: 58px\n    flex: 1\n    flex-shrink: 0\n  ' /*|cmz*/),
 
-  formKeywords: cmz.named('AutoUI_ui_SearchForm-100', /*cmz|*/'\n    margin: 0 10px\n    min-width: 300px\n    height: 58px\n    flex: 1\n    flex-shrink: 0\n  ' /*|cmz*/),
+  selectFields: cmz.named('AutoUI_ui_SearchForm-96', /*cmz|*/'\n    flex-shrink: 0\n    width: 300px\n    margin: 0 10px\n  ' /*|cmz*/),
 
-  selectFields: cmz.named('AutoUI_ui_SearchForm-108', /*cmz|*/'\n    flex-shrink: 0\n    width: 300px\n    margin: 0 10px\n  ' /*|cmz*/),
+  formButton: cmz.named('AutoUI_ui_SearchForm-102', /*cmz|*/'\n    margin: 0 10px\n    height: 58px\n  ' /*|cmz*/),
 
-  formButton: cmz.named('AutoUI_ui_SearchForm-114', /*cmz|*/'\n    margin: 0 10px\n    height: 58px\n  ' /*|cmz*/),
-
-  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-119', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBrighter + '\n    padding: 10px 30px 30px\n    box-sizing: border-box\n  ')
+  applicantsStatusFilter: cmz.named('AutoUI_ui_SearchForm-107', '\n    width: 100%\n    background-color: ' + _theme2.default.baseBrighter + '\n    padding: 10px 30px 30px\n    box-sizing: border-box\n  ')
 };
 
 var SearchForm = function (_PureComponent) {
@@ -19558,7 +19554,6 @@ var SearchForm = function (_PureComponent) {
           mode = _props.mode,
           lists = _props.lists,
           onSelectList = _props.onSelectList,
-          onClickShowLists = _props.onClickShowLists,
           keywords = _props.keywords,
           onChangeKeywords = _props.onChangeKeywords,
           fields = _props.fields,
@@ -19595,18 +19590,7 @@ var SearchForm = function (_PureComponent) {
                   ' Edit lists'
                 )
               )
-            }),
-            _react2.default.createElement(
-              _Button2.default,
-              {
-                className: theme.listsButton,
-                type: 'button',
-                size: 'large',
-                raised: true,
-                onClick: onClickShowLists
-              },
-              'Show'
-            )
+            })
           ),
           _react2.default.createElement(_Keywords2.default, {
             values: keywords,
@@ -19634,7 +19618,7 @@ var SearchForm = function (_PureComponent) {
               size: 'large',
               raised: true
             },
-            'Filter'
+            'Show'
           )
         ),
         renderApplicantsStatusFilter && _react2.default.createElement(
@@ -19653,7 +19637,6 @@ SearchForm.defaultProps = {
   mode: 'card',
   lists: [],
   onSelectList: function onSelectList() {},
-  onClickShowLists: function onClickShowLists() {},
   keywords: '',
   onChangeKeywords: function onChangeKeywords() {},
   fields: [],

--- a/src/components/ui/SearchForm.js
+++ b/src/components/ui/SearchForm.js
@@ -26,12 +26,6 @@ const cardTheme = {
     }
   `),
 
-  listsButton: cmz(`
-    width: 100px
-    height: 58px
-    margin-left: 10px
-  `),
-
   selectLists: cmz(`
     display: flex
     align-items: center
@@ -47,7 +41,7 @@ const cardTheme = {
 
   selectFields: cmz(`
     display: inline-block
-    width: 50%
+    width: 100%
     margin-top: 20px
   `),
 
@@ -82,12 +76,6 @@ const tabularTheme = {
     width: 100%
     padding: 50px 30px 30px
     box-sizing: border-box
-  `),
-
-  listsButton: cmz(`
-    margin: 0 10px 0 20px
-    width: 100px
-    height: 58px
   `),
 
   selectLists: cmz(`
@@ -128,7 +116,6 @@ type Props = {
   mode: 'card' | 'tabular',
   lists: Array<*>,
   onSelectList: Function,
-  onClickShowLists: Function,
   keywords: string,
   onChangeKeywords: Function,
   fields: Array<*>,
@@ -143,7 +130,6 @@ class SearchForm extends PureComponent<Props> {
     mode: 'card',
     lists: [],
     onSelectList: () => {},
-    onClickShowLists: () => {},
     keywords: '',
     onChangeKeywords: () => {},
     fields: [],
@@ -163,7 +149,6 @@ class SearchForm extends PureComponent<Props> {
       mode,
       lists,
       onSelectList,
-      onClickShowLists,
       keywords,
       onChangeKeywords,
       fields,
@@ -191,15 +176,6 @@ class SearchForm extends PureComponent<Props> {
                 </Button>
               }
             />
-            <Button
-              className={theme.listsButton}
-              type='button'
-              size='large'
-              raised
-              onClick={onClickShowLists}
-            >
-              Show
-            </Button>
           </div>
           <Keywords
             values={keywords}
@@ -223,7 +199,7 @@ class SearchForm extends PureComponent<Props> {
             size='large'
             raised
           >
-            Filter
+            Show
           </Button>
         </form>
         {renderApplicantsStatusFilter && (


### PR DESCRIPTION
**Release Type:** *Breaking change*

Fixes https://x-team-internal.atlassian.net/browse/XP-2239

## Description

These changes remove the show button from the search form and rename the `Filter` button text by `Show`.

## Checklist

**Before submitting a pull request,** please make sure the following is done:

<!-- Remove items that do not apply. Just tick completed items in UI -->
- [X] set yourself as an assignee
- [X] set appropriate labels for a PR (initially it's mostly `[zube]: In Review`)
- [X] set `[zube]: In Review` label for respective issue as well
- [X] make sure your code lints (`npm run lint`)
- [X] Flow typechecks passed (`npm run typecheck`)
- [X] **manually tested the app** by running it in the browser and checked nothing is broken and operates as expected!

## Related PRs

List related PRs against other Auto repos if applicable:

Branch | PR
------ | ------
XP-2239-remove-show-button-and-rename-filter-button | [Auto](https://github.com/x-team/auto/pull/1531)

## Steps to Test or Reproduce

1. Go to the Search applicants/list screen. 
2. The show button next to the lists select should be removed.
3. The text of the `Filter` button should be changed to `Show`.
4. The search form works as expected.

## Impacted Areas in Application

List Screen and Search Form.

## Screenshots
![remove-show-button](https://user-images.githubusercontent.com/7307503/45647756-ad497a00-ba94-11e8-947a-63eb702a8f36.gif)

