### PR TITLE
Fix AdminScreen z-index

### DIFF
--- a/.snapguidist/__snapshots__/Keywords-1.snap
+++ b/.snapguidist/__snapshots__/Keywords-1.snap
@@ -55,7 +55,7 @@ exports[`Keywords-1 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-16--value">
+      id="react-select-12--value">
       <div
         className="Select-value">
         <span
@@ -66,7 +66,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-0"
+          id="react-select-12--value-0"
           role="option">
           a
           <span
@@ -85,7 +85,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-1"
+          id="react-select-12--value-1"
           role="option">
           simple
           <span
@@ -104,7 +104,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-2"
+          id="react-select-12--value-2"
           role="option">
           string
           <span
@@ -123,7 +123,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-3"
+          id="react-select-12--value-3"
           role="option">
           separated
           <span
@@ -142,7 +142,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-4"
+          id="react-select-12--value-4"
           role="option">
           by
           <span
@@ -161,7 +161,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-5"
+          id="react-select-12--value-5"
           role="option">
           commas
           <span
@@ -180,7 +180,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-6"
+          id="react-select-12--value-6"
           role="option">
           with
           <span
@@ -199,7 +199,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-7"
+          id="react-select-12--value-7"
           role="option">
           operators
           <span
@@ -218,7 +218,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-8"
+          id="react-select-12--value-8"
           role="option">
           AND
           <span
@@ -237,7 +237,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-16--value-9"
+          id="react-select-12--value-9"
           role="option">
           OR
           <span
@@ -254,7 +254,7 @@ exports[`Keywords-1 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-16--value"
+          aria-activedescendant="react-select-12--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Keywords-3.snap
+++ b/.snapguidist/__snapshots__/Keywords-3.snap
@@ -5,7 +5,7 @@ exports[`Keywords-3 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-15--value">
+      id="react-select-13--value">
       <div
         className="Select-placeholder">
         Type keywords
@@ -18,7 +18,7 @@ exports[`Keywords-3 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-15--value"
+          aria-activedescendant="react-select-13--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-1.snap
+++ b/.snapguidist/__snapshots__/SearchForm-1.snap
@@ -452,7 +452,7 @@ exports[`SearchForm-1 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-12--value">
+          id="react-select-14--value">
           <div
             className="Select-value">
             <span
@@ -463,7 +463,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-0"
+              id="react-select-14--value-0"
               role="option">
               a keyword
               <span
@@ -482,7 +482,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-1"
+              id="react-select-14--value-1"
               role="option">
               OR
               <span
@@ -501,7 +501,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-2"
+              id="react-select-14--value-2"
               role="option">
               two
               <span
@@ -520,7 +520,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-3"
+              id="react-select-14--value-3"
               role="option">
               AND
               <span
@@ -539,7 +539,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-4"
+              id="react-select-14--value-4"
               role="option">
               much more
               <span
@@ -556,7 +556,7 @@ exports[`SearchForm-1 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-12--value"
+              aria-activedescendant="react-select-14--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-3.snap
+++ b/.snapguidist/__snapshots__/SearchForm-3.snap
@@ -355,7 +355,7 @@ exports[`SearchForm-3 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-13--value">
+          id="react-select-15--value">
           <div
             className="Select-value">
             <span
@@ -366,7 +366,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-13--value-0"
+              id="react-select-15--value-0"
               role="option">
               a keyword
               <span
@@ -385,7 +385,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-13--value-1"
+              id="react-select-15--value-1"
               role="option">
               OR
               <span
@@ -404,7 +404,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-13--value-2"
+              id="react-select-15--value-2"
               role="option">
               two
               <span
@@ -423,7 +423,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-13--value-3"
+              id="react-select-15--value-3"
               role="option">
               AND
               <span
@@ -442,7 +442,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-13--value-4"
+              id="react-select-15--value-4"
               role="option">
               much more
               <span
@@ -459,7 +459,7 @@ exports[`SearchForm-3 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-13--value"
+              aria-activedescendant="react-select-15--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-5.snap
+++ b/.snapguidist/__snapshots__/SearchForm-5.snap
@@ -357,7 +357,7 @@ exports[`SearchForm-5 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-14--value">
+          id="react-select-16--value">
           <div
             className="Select-placeholder">
             Type keywords
@@ -370,7 +370,7 @@ exports[`SearchForm-5 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-14--value"
+              aria-activedescendant="react-select-16--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -7555,7 +7555,7 @@ var cmz = __webpack_require__(1);
 var cx = {
   admin: cmz.named('AutoUI_ui_AdminScreen-12', /*cmz|*/'\n    height: 100%\n    position: relative\n  ' /*|cmz*/),
 
-  header: cmz.named('AutoUI_ui_AdminScreen-17', /*cmz|*/'\n    height: 86px\n    position: relative\n    z-index: 1\n  ' /*|cmz*/)
+  header: cmz.named('AutoUI_ui_AdminScreen-17', /*cmz|*/'\n    height: 86px\n    position: relative\n    z-index: 10000\n  ' /*|cmz*/)
 };
 
 var AdminScreen = function (_PureComponent) {

--- a/src/components/ui/AdminScreen.js
+++ b/src/components/ui/AdminScreen.js
@@ -17,7 +17,7 @@ const cx = {
   header: cmz(`
     height: 86px
     position: relative
-    z-index: 1
+    z-index: 10000
   `)
 }
 


### PR DESCRIPTION
**Release Type:** *[Bug fix]* <!-- Refer to the wiki https://github.com/x-team/auto/wiki/Release-Process#types-of-releases -->
<!--
Basic types are:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->

Fixes https://x-team-internal.atlassian.net/browse/XP-2291

## Description

This small fix adjusts the `z-index` in `components/ui/AdminScreen.js:20` this is the container of the `Dropdown` that was showing this issue.

z-index is set to `10000` because it has to be higher than: 

- `components/ui/ListsScreen.js:69`
- `components/ui/SelectBox.js:23`

## Checklist

**Before submitting a pull request,** please make sure the following is done:

- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (initially it's mostly `[zube]: In Review`)
- [x] set `[zube]: In Review` label for respective issue as well
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run typecheck`)
- [x] **manually tested the component** by running it in the browser and checked nothing is broken and operates as expected!

## Steps to Test or Reproduce

- Go to admin site and adjust the screen size so that the hamburger menu is above the search filters:

![image](https://user-images.githubusercontent.com/3914150/46492701-f0655600-c7d3-11e8-9717-6ccc2118d5e5.png)

- Select "View in Tabular Mode" and do likewise:

![image](https://user-images.githubusercontent.com/3914150/46492471-4259ac00-c7d3-11e8-904d-87963972bfc9.png)

## Screenshots

Before :-1: :

![image](https://user-images.githubusercontent.com/3914150/46492010-05d98080-c7d2-11e8-8ca3-ed64eca76dd2.png)

After :tada: :tada:  :

![image](https://user-images.githubusercontent.com/3914150/46492000-fe19dc00-c7d1-11e8-910c-a53e21ebfe6f.png)