### PR TITLE
Include SettingsScreen

### DIFF
--- a/.snapguidist/__snapshots__/ColorPalette-1.snap
+++ b/.snapguidist/__snapshots__/ColorPalette-1.snap
@@ -161,12 +161,36 @@ exports[`ColorPalette-1 1`] = `
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
     style={
       Object {
+        "backgroundColor": "rgb(184, 183, 188)",
+      }
+    }>
+    <div
+      className="AutoUI_ui_ColorPalette-34">
+      typoParagraphOnDarkBackground
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+    style={
+      Object {
         "backgroundColor": "rgb(19, 14, 46)",
       }
     }>
     <div
       className="AutoUI_ui_ColorPalette-34">
       typoHighlight
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+    style={
+      Object {
+        "backgroundColor": "rgb(90, 86, 101)",
+      }
+    }>
+    <div
+      className="AutoUI_ui_ColorPalette-34">
+      typoHighlightOnDarkBackground
     </div>
   </div>
   <div

--- a/.snapguidist/__snapshots__/Keywords-1.snap
+++ b/.snapguidist/__snapshots__/Keywords-1.snap
@@ -55,7 +55,7 @@ exports[`Keywords-1 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-12--value">
+      id="react-select-27--value">
       <div
         className="Select-value">
         <span
@@ -66,7 +66,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-0"
+          id="react-select-27--value-0"
           role="option">
           a
           <span
@@ -85,7 +85,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-1"
+          id="react-select-27--value-1"
           role="option">
           simple
           <span
@@ -104,7 +104,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-2"
+          id="react-select-27--value-2"
           role="option">
           string
           <span
@@ -123,7 +123,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-3"
+          id="react-select-27--value-3"
           role="option">
           separated
           <span
@@ -142,7 +142,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-4"
+          id="react-select-27--value-4"
           role="option">
           by
           <span
@@ -161,7 +161,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-5"
+          id="react-select-27--value-5"
           role="option">
           commas
           <span
@@ -180,7 +180,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-6"
+          id="react-select-27--value-6"
           role="option">
           with
           <span
@@ -199,7 +199,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-7"
+          id="react-select-27--value-7"
           role="option">
           operators
           <span
@@ -218,7 +218,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-8"
+          id="react-select-27--value-8"
           role="option">
           AND
           <span
@@ -237,7 +237,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-9"
+          id="react-select-27--value-9"
           role="option">
           OR
           <span
@@ -254,7 +254,7 @@ exports[`Keywords-1 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-12--value"
+          aria-activedescendant="react-select-27--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Keywords-3.snap
+++ b/.snapguidist/__snapshots__/Keywords-3.snap
@@ -5,7 +5,7 @@ exports[`Keywords-3 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-13--value">
+      id="react-select-28--value">
       <div
         className="Select-placeholder">
         Type keywords
@@ -18,7 +18,7 @@ exports[`Keywords-3 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-13--value"
+          aria-activedescendant="react-select-28--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-1.snap
+++ b/.snapguidist/__snapshots__/SearchForm-1.snap
@@ -117,6 +117,7 @@ exports[`SearchForm-1 1`] = `
                     <input
                       aria-labelledby="label-search"
                       autoComplete="off"
+                      autoFocus={false}
                       className="AutoUI_typo-181 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-87 AutoUI_ui_SelectBox-111"
                       id="search"
                       name="search"
@@ -365,6 +366,7 @@ exports[`SearchForm-1 1`] = `
                   <input
                     aria-labelledby="label-search"
                     autoComplete="off"
+                    autoFocus={false}
                     className="AutoUI_typo-181 AutoUI_typo-53 AutoUI_typo-40 AutoUI_forms_InputField-87 AutoUI_ui_SelectBox-111"
                     id="search"
                     name="search"
@@ -452,7 +454,7 @@ exports[`SearchForm-1 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-14--value">
+          id="react-select-29--value">
           <div
             className="Select-value">
             <span
@@ -463,7 +465,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-0"
+              id="react-select-29--value-0"
               role="option">
               a keyword
               <span
@@ -482,7 +484,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-1"
+              id="react-select-29--value-1"
               role="option">
               OR
               <span
@@ -501,7 +503,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-2"
+              id="react-select-29--value-2"
               role="option">
               two
               <span
@@ -520,7 +522,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-3"
+              id="react-select-29--value-3"
               role="option">
               AND
               <span
@@ -539,7 +541,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-4"
+              id="react-select-29--value-4"
               role="option">
               much more
               <span
@@ -556,7 +558,7 @@ exports[`SearchForm-1 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-14--value"
+              aria-activedescendant="react-select-29--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-3.snap
+++ b/.snapguidist/__snapshots__/SearchForm-3.snap
@@ -357,7 +357,7 @@ exports[`SearchForm-3 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-12--value">
+          id="react-select-30--value">
           <div
             className="Select-value">
             <span
@@ -368,7 +368,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-0"
+              id="react-select-30--value-0"
               role="option">
               a keyword
               <span
@@ -387,7 +387,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-1"
+              id="react-select-30--value-1"
               role="option">
               OR
               <span
@@ -406,7 +406,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-2"
+              id="react-select-30--value-2"
               role="option">
               two
               <span
@@ -425,7 +425,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-3"
+              id="react-select-30--value-3"
               role="option">
               AND
               <span
@@ -444,7 +444,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-12--value-4"
+              id="react-select-30--value-4"
               role="option">
               much more
               <span
@@ -461,7 +461,7 @@ exports[`SearchForm-3 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-12--value"
+              aria-activedescendant="react-select-30--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-5.snap
+++ b/.snapguidist/__snapshots__/SearchForm-5.snap
@@ -359,7 +359,7 @@ exports[`SearchForm-5 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-13--value">
+          id="react-select-31--value">
           <div
             className="Select-placeholder">
             Type keywords
@@ -372,7 +372,7 @@ exports[`SearchForm-5 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-13--value"
+              aria-activedescendant="react-select-31--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SettingsScreen-0.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-0.snap
@@ -1,0 +1,327 @@
+exports[`SettingsScreen-0 1`] = `
+<div
+  style={
+    Object {
+      "height": "500px",
+    }
+  }>
+  <div
+    className="AutoUI_ui_SettingsScreen-13">
+    <div
+      className="AutoUI_ui_SettingsScreen-19">
+      <h1
+        className="AutoUI_ui_SettingsScreen-29 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+        Settings
+      </h1>
+      <ul
+        className="AutoUI_ui_SettingsScreen-34">
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+        <li>
+          Menu link
+        </li>
+      </ul>
+    </div>
+    <div
+      className="AutoUI_ui_SettingsScreen-40">
+      <div>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/SettingsScreen-1.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-1.snap
@@ -3,6 +3,7 @@ exports[`SettingsScreen-1 1`] = `
   style={
     Object {
       "height": "500px",
+      "overflow": "hidden",
     }
   }>
   <div
@@ -14,359 +15,359 @@ exports[`SettingsScreen-1 1`] = `
         Settings
       </h1>
       <ul
-        className="AutoUI_ui_SettingsScreen-35 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
+        className="AutoUI_ui_SettingsScreen-37 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <a
             href="#">
             Menu link
           </a>
         </li>
         <li
-          className="AutoUI_ui_SettingsScreen-45">
+          className="AutoUI_ui_SettingsScreen-49 AutoUI_typo-118 AutoUI_typo-53 AutoUI_typo-34">
           <p>
             A strangely wide menu item just to make it more difficult and breakable, also this is not a link (
             <a
@@ -379,7 +380,7 @@ exports[`SettingsScreen-1 1`] = `
       </ul>
     </div>
     <div
-      className="AutoUI_ui_SettingsScreen-61">
+      className="AutoUI_ui_SettingsScreen-69">
       <div>
         <p>
           Anything goes in the content

--- a/.snapguidist/__snapshots__/SettingsScreen-1.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-1.snap
@@ -6,13 +6,531 @@ exports[`SettingsScreen-1 1`] = `
     }
   }>
   <div
-    className="AutoUI_ui_SettingsScreen-12">
+    className="AutoUI_ui_SettingsScreen-13">
     <div
-      className="AutoUI_ui_SettingsScreen-18" />
+      className="AutoUI_ui_SettingsScreen-19">
+      <h1
+        className="AutoUI_ui_SettingsScreen-29 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+        Settings
+      </h1>
+      <ul
+        className="AutoUI_ui_SettingsScreen-35 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <a
+            href="#">
+            Menu link
+          </a>
+        </li>
+        <li
+          className="AutoUI_ui_SettingsScreen-45">
+          <p>
+            A strangely wide menu item just to make it more difficult and breakable, also this is not a link (
+            <a
+              href="#">
+              this is a link
+            </a>
+            ), this is just text...
+          </p>
+        </li>
+      </ul>
+    </div>
     <div
-      className="AutoUI_ui_SettingsScreen-25">
+      className="AutoUI_ui_SettingsScreen-61">
       <div>
-        Anything goes in the content
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
+        <p>
+          Anything goes in the content
+        </p>
       </div>
     </div>
   </div>

--- a/.snapguidist/__snapshots__/SettingsScreen-1.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-1.snap
@@ -1,0 +1,20 @@
+exports[`SettingsScreen-1 1`] = `
+<div
+  style={
+    Object {
+      "height": "500px",
+    }
+  }>
+  <div
+    className="AutoUI_ui_SettingsScreen-12">
+    <div
+      className="AutoUI_ui_SettingsScreen-18" />
+    <div
+      className="AutoUI_ui_SettingsScreen-25">
+      <div>
+        Anything goes in the content
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/SettingsScreen-3.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-3.snap
@@ -8,9 +8,9 @@ exports[`SettingsScreen-3 1`] = `
       Settings
     </h1>
     <ul
-      className="AutoUI_ui_SettingsScreen-35 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40" />
+      className="AutoUI_ui_SettingsScreen-37 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40" />
   </div>
   <div
-    className="AutoUI_ui_SettingsScreen-61" />
+    className="AutoUI_ui_SettingsScreen-69" />
 </div>
 `;

--- a/.snapguidist/__snapshots__/SettingsScreen-3.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-3.snap
@@ -1,0 +1,20 @@
+exports[`SettingsScreen-3 1`] = `
+<div
+  style={
+    Object {
+      "height": "500px",
+    }
+  }>
+  <div
+    className="AutoUI_ui_SettingsScreen-12">
+    <div
+      className="AutoUI_ui_SettingsScreen-18" />
+    <div
+      className="AutoUI_ui_SettingsScreen-25">
+      <div>
+        Anything goes in the content
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/.snapguidist/__snapshots__/SettingsScreen-3.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-3.snap
@@ -1,20 +1,16 @@
 exports[`SettingsScreen-3 1`] = `
 <div
-  style={
-    Object {
-      "height": "500px",
-    }
-  }>
+  className="AutoUI_ui_SettingsScreen-13">
   <div
-    className="AutoUI_ui_SettingsScreen-12">
-    <div
-      className="AutoUI_ui_SettingsScreen-18" />
-    <div
-      className="AutoUI_ui_SettingsScreen-25">
-      <div>
-        Anything goes in the content
-      </div>
-    </div>
+    className="AutoUI_ui_SettingsScreen-19">
+    <h1
+      className="AutoUI_ui_SettingsScreen-29 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34">
+      Settings
+    </h1>
+    <ul
+      className="AutoUI_ui_SettingsScreen-35 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40" />
   </div>
+  <div
+    className="AutoUI_ui_SettingsScreen-61" />
 </div>
 `;

--- a/.snapguidist/__snapshots__/SettingsScreen-5.snap
+++ b/.snapguidist/__snapshots__/SettingsScreen-5.snap
@@ -1,0 +1,9 @@
+exports[`SettingsScreen-5 1`] = `
+<div
+  className="AutoUI_ui_SettingsScreen-12">
+  <div
+    className="AutoUI_ui_SettingsScreen-18" />
+  <div
+    className="AutoUI_ui_SettingsScreen-25" />
+</div>
+`;

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -7371,7 +7371,7 @@ exports.default = RoadmapTimelineElement;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.XIcon = exports.VideoPlayer = exports.Typography = exports.TruncatedList = exports.TextareaEditor = exports.Text = exports.Tabs = exports.Tab = exports.SettingsScreen = exports.SvgIcon = exports.SolutionForm = exports.SelectBox = exports.SearchForm = exports.RoadmapTimelineElement = exports.RoadmapLevel = exports.RoadmapHero = exports.Roadmap = exports.ProfileHeaderLinks = exports.PencilButton = exports.NotesFeed = exports.Note = exports.Modal = exports.MilestonesScreen = exports.Milestones = exports.Loader = exports.ListsScreen = exports.ListsEditor = exports.Keywords = exports.InputGroup = exports.InputField = exports.InlineEditor = exports.HorizontalRuler = exports.HeaderBar = exports.FooterList = exports.FooterBrands = exports.Footer = exports.ErrorBox = exports.Dropdown = exports.ColorPalette = exports.CollapsibleSection = exports.Button = exports.Avatar = exports.AttachFiles = exports.ApplicantScreen = exports.ApplicantListFilter = exports.ApplicantGridHeader = exports.ApplicantGrid = exports.ApplicantBadge = exports.AdminScreen = undefined;
+exports.XIcon = exports.VideoPlayer = exports.Typography = exports.TruncatedList = exports.TextareaEditor = exports.Text = exports.Tabs = exports.Tab = exports.SvgIcon = exports.SolutionForm = exports.SettingsScreen = exports.SelectBox = exports.SearchForm = exports.RoadmapTimelineElement = exports.RoadmapLevel = exports.RoadmapHero = exports.Roadmap = exports.ProfileHeaderLinks = exports.PencilButton = exports.NotesFeed = exports.Note = exports.Modal = exports.MilestonesScreen = exports.Milestones = exports.Loader = exports.ListsScreen = exports.ListsEditor = exports.Keywords = exports.InputGroup = exports.InputField = exports.InlineEditor = exports.HorizontalRuler = exports.HeaderBar = exports.FooterList = exports.FooterBrands = exports.Footer = exports.ErrorBox = exports.Dropdown = exports.ColorPalette = exports.CollapsibleSection = exports.Button = exports.Avatar = exports.AttachFiles = exports.ApplicantScreen = exports.ApplicantListFilter = exports.ApplicantGridHeader = exports.ApplicantGrid = exports.ApplicantBadge = exports.AdminScreen = undefined;
 
 var _AdminScreen = __webpack_require__(48);
 
@@ -7525,13 +7525,13 @@ var _SelectBox = __webpack_require__(22);
 
 var _SelectBox2 = _interopRequireDefault(_SelectBox);
 
-var _SolutionForm = __webpack_require__(136);
-
-var _SolutionForm2 = _interopRequireDefault(_SolutionForm);
-
-var _SettingsScreen = __webpack_require__(138);
+var _SettingsScreen = __webpack_require__(136);
 
 var _SettingsScreen2 = _interopRequireDefault(_SettingsScreen);
+
+var _SolutionForm = __webpack_require__(137);
+
+var _SolutionForm2 = _interopRequireDefault(_SolutionForm);
 
 var _SvgIcon = __webpack_require__(5);
 
@@ -7609,9 +7609,9 @@ exports.RoadmapLevel = _RoadmapLevel2.default;
 exports.RoadmapTimelineElement = _RoadmapTimelineElement2.default;
 exports.SearchForm = _SearchForm2.default;
 exports.SelectBox = _SelectBox2.default;
+exports.SettingsScreen = _SettingsScreen2.default;
 exports.SolutionForm = _SolutionForm2.default;
 exports.SvgIcon = _SvgIcon2.default;
-exports.SettingsScreen = _SettingsScreen2.default;
 exports.Tab = _Tab2.default;
 exports.Tabs = _Tabs2.default;
 exports.Text = _Text2.default;
@@ -31147,7 +31147,114 @@ var _react = __webpack_require__(0);
 
 var _react2 = _interopRequireDefault(_react);
 
-var _Title = __webpack_require__(137);
+var _theme = __webpack_require__(2);
+
+var _theme2 = _interopRequireDefault(_theme);
+
+var _typo = __webpack_require__(4);
+
+var _typo2 = _interopRequireDefault(_typo);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var cmz = __webpack_require__(1);
+
+var cx = {
+  main: cmz.named('AutoUI_ui_SettingsScreen-13', /*cmz|*/'\n    height: calc(100vh - 86px)\n    position: relative\n    display: flex\n  ' /*|cmz*/),
+
+  navigation: cmz.named('AutoUI_ui_SettingsScreen-19', '\n    box-sizing: border-box\n    height: 100%\n    width: 315px\n    overflow: auto\n    background-color: ' + _theme2.default.baseBright + '\n    border-right: 2px solid ' + _theme2.default.lineSilver1 + '\n    padding: 51px 50px 65px 70px\n  '),
+
+  heading: cmz.named('AutoUI_ui_SettingsScreen-29', _typo2.default.sectionHeading, '\n    text-transform: uppercase\n    font-size: 26px\n    font-weight: 800\n    margin: 0 0 40px\n    color: ' + _theme2.default.typoHighlightOnDarkBackground + '\n  '),
+
+  menu: cmz.named('AutoUI_ui_SettingsScreen-37', _typo2.default.baseText, '\n      font-size: 16px\n      line-height: 1.6\n      text-transform: uppercase\n      list-style: none\n      padding: 0\n      margin: 0\n      color: ' + _theme2.default.typoParagraphOnDarkBackground + '\n    '),
+
+  menuItem: cmz.named('AutoUI_ui_SettingsScreen-49', _typo2.default.badgeHeading, '\n      & {\n        margin: 20px 0\n      }\n\n      & a {\n        text-decoration: none\n        color: ' + _theme2.default.typoParagraphOnDarkBackground + '\n        font-size: 13px\n        letter-spacing: 1px\n      }\n\n      & a:hover,\n      & a.activeLink {\n        color: ' + _theme2.default.typoHighlightOnDarkBackground + '\n      }\n    '),
+
+  content: cmz.named('AutoUI_ui_SettingsScreen-69', /*cmz|*/'\n    box-sizing: border-box\n    height: 100%\n    flex: 1\n    overflow: auto\n    padding: 65px 100px\n  ' /*|cmz*/)
+};
+
+var SettingsScreen = function (_PureComponent) {
+  _inherits(SettingsScreen, _PureComponent);
+
+  function SettingsScreen() {
+    _classCallCheck(this, SettingsScreen);
+
+    return _possibleConstructorReturn(this, (SettingsScreen.__proto__ || Object.getPrototypeOf(SettingsScreen)).apply(this, arguments));
+  }
+
+  _createClass(SettingsScreen, [{
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          menu = _props.menu,
+          children = _props.children;
+
+
+      return _react2.default.createElement(
+        'div',
+        { className: cx.main },
+        _react2.default.createElement(
+          'div',
+          { className: cx.navigation },
+          _react2.default.createElement(
+            'h1',
+            { className: cx.heading },
+            'Settings'
+          ),
+          _react2.default.createElement(
+            'ul',
+            { className: cx.menu },
+            menu.map(function (item, i) {
+              return _react2.default.createElement(
+                'li',
+                { key: i, className: cx.menuItem },
+                item
+              );
+            })
+          )
+        ),
+        _react2.default.createElement(
+          'div',
+          { className: cx.content },
+          children
+        )
+      );
+    }
+  }]);
+
+  return SettingsScreen;
+}(_react.PureComponent);
+
+SettingsScreen.defaultProps = {
+  menu: [],
+  children: null
+};
+exports.default = SettingsScreen;
+
+/***/ }),
+/* 137 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = __webpack_require__(0);
+
+var _react2 = _interopRequireDefault(_react);
+
+var _Title = __webpack_require__(138);
 
 var _Title2 = _interopRequireDefault(_Title);
 
@@ -31243,7 +31350,7 @@ SolutionForm.defaultProps = {
 exports.default = SolutionForm;
 
 /***/ }),
-/* 137 */
+/* 138 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -31311,112 +31418,6 @@ SolutionFormTitle.defaultProps = {
   maxAttempts: 3
 };
 exports.default = SolutionFormTitle;
-
-/***/ }),
-/* 138 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-var _react = __webpack_require__(0);
-
-var _react2 = _interopRequireDefault(_react);
-
-var _theme = __webpack_require__(2);
-
-var _theme2 = _interopRequireDefault(_theme);
-
-var _typo = __webpack_require__(4);
-
-var _typo2 = _interopRequireDefault(_typo);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-var cmz = __webpack_require__(1);
-
-var cx = {
-  main: cmz.named('AutoUI_ui_SettingsScreen-13', /*cmz|*/'\n    height: calc(100vh - 86px)\n    position: relative\n    display: flex\n  ' /*|cmz*/),
-
-  navigation: cmz.named('AutoUI_ui_SettingsScreen-19', '\n    box-sizing: border-box\n    height: 100%\n    width: 315px\n    overflow: auto\n    background-color: ' + _theme2.default.baseBright + '\n    border-right: 2px solid ' + _theme2.default.lineSilver1 + '\n    padding: 65px 50px 65px 70px\n  '),
-
-  heading: cmz.named('AutoUI_ui_SettingsScreen-29', _typo2.default.sectionHeading, '\n    text-transform: uppercase\n    margin: 0 0 40px\n    color: ' + _theme2.default.typoHighlightOnDarkBackground + '\n  '),
-
-  menu: cmz.named('AutoUI_ui_SettingsScreen-35', _typo2.default.baseText, '\n    font-size: 16px\n    line-height: 1.6\n    text-transform: uppercase\n    list-style: none\n    padding: 0\n    margin: 0\n    color: ' + _theme2.default.typoParagraphOnDarkBackground + '\n  '),
-
-  menuItem: cmz.named('AutoUI_ui_SettingsScreen-45', '\n    & {\n      margin: 20px 0\n    }\n\n    & a {\n      text-decoration: none\n      color: ' + _theme2.default.typoParagraphOnDarkBackground + '\n    }\n\n    & a:hover,\n    & a.activeLink {\n      color: ' + _theme2.default.typoHighlightOnDarkBackground + '\n    }\n  '),
-
-  content: cmz.named('AutoUI_ui_SettingsScreen-61', /*cmz|*/'\n    box-sizing: border-box\n    height: 100%\n    flex: 1\n    overflow: auto\n    padding: 65px 100px\n  ' /*|cmz*/)
-};
-
-var SettingsScreen = function (_PureComponent) {
-  _inherits(SettingsScreen, _PureComponent);
-
-  function SettingsScreen() {
-    _classCallCheck(this, SettingsScreen);
-
-    return _possibleConstructorReturn(this, (SettingsScreen.__proto__ || Object.getPrototypeOf(SettingsScreen)).apply(this, arguments));
-  }
-
-  _createClass(SettingsScreen, [{
-    key: 'render',
-    value: function render() {
-      var _props = this.props,
-          menu = _props.menu,
-          children = _props.children;
-
-      return _react2.default.createElement(
-        'div',
-        { className: cx.main },
-        _react2.default.createElement(
-          'div',
-          { className: cx.navigation },
-          _react2.default.createElement(
-            'h1',
-            { className: cx.heading },
-            'Settings'
-          ),
-          _react2.default.createElement(
-            'ul',
-            { className: cx.menu },
-            menu.map(function (item, i) {
-              return _react2.default.createElement(
-                'li',
-                { key: i, className: cx.menuItem },
-                item
-              );
-            })
-          )
-        ),
-        _react2.default.createElement(
-          'div',
-          { className: cx.content },
-          children
-        )
-      );
-    }
-  }]);
-
-  return SettingsScreen;
-}(_react.PureComponent);
-
-SettingsScreen.defaultProps = {
-  menu: [],
-  children: null
-};
-exports.default = SettingsScreen;
 
 /***/ }),
 /* 139 */

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -211,7 +211,9 @@ var palette = {
   bombay: '#B2B6BC',
   lima: '#5fcf21',
   ripeLemon: '#f8e71c',
-  frenchGray: '#c2c1c5'
+  frenchGray: '#c2c1c5',
+  frenchGrayDarker: '#B8B7BC',
+  scarpaFlow: '#5A5665'
 };
 
 exports.default = wrap({
@@ -229,7 +231,9 @@ exports.default = wrap({
   typoHeading: palette.tuna,
   typoSubheading: palette.radicalRed,
   typoParagraph: palette.tuna,
+  typoParagraphOnDarkBackground: palette.frenchGrayDarker,
   typoHighlight: palette.haiti,
+  typoHighlightOnDarkBackground: palette.scarpaFlow,
   typoLabel: palette.bombay,
 
   sliderToggle: palette.bombay,
@@ -7367,7 +7371,7 @@ exports.default = RoadmapTimelineElement;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.XIcon = exports.VideoPlayer = exports.Typography = exports.TruncatedList = exports.TextareaEditor = exports.Text = exports.Tabs = exports.Tab = exports.SvgIcon = exports.SolutionForm = exports.SelectBox = exports.SearchForm = exports.RoadmapTimelineElement = exports.RoadmapLevel = exports.RoadmapHero = exports.Roadmap = exports.ProfileHeaderLinks = exports.PencilButton = exports.NotesFeed = exports.Note = exports.Modal = exports.MilestonesScreen = exports.Milestones = exports.Loader = exports.ListsScreen = exports.ListsEditor = exports.Keywords = exports.InputGroup = exports.InputField = exports.InlineEditor = exports.HorizontalRuler = exports.HeaderBar = exports.FooterList = exports.FooterBrands = exports.Footer = exports.ErrorBox = exports.Dropdown = exports.ColorPalette = exports.CollapsibleSection = exports.Button = exports.Avatar = exports.AttachFiles = exports.ApplicantScreen = exports.ApplicantListFilter = exports.ApplicantGridHeader = exports.ApplicantGrid = exports.ApplicantBadge = exports.AdminScreen = undefined;
+exports.XIcon = exports.VideoPlayer = exports.Typography = exports.TruncatedList = exports.TextareaEditor = exports.Text = exports.Tabs = exports.Tab = exports.SettingsScreen = exports.SvgIcon = exports.SolutionForm = exports.SelectBox = exports.SearchForm = exports.RoadmapTimelineElement = exports.RoadmapLevel = exports.RoadmapHero = exports.Roadmap = exports.ProfileHeaderLinks = exports.PencilButton = exports.NotesFeed = exports.Note = exports.Modal = exports.MilestonesScreen = exports.Milestones = exports.Loader = exports.ListsScreen = exports.ListsEditor = exports.Keywords = exports.InputGroup = exports.InputField = exports.InlineEditor = exports.HorizontalRuler = exports.HeaderBar = exports.FooterList = exports.FooterBrands = exports.Footer = exports.ErrorBox = exports.Dropdown = exports.ColorPalette = exports.CollapsibleSection = exports.Button = exports.Avatar = exports.AttachFiles = exports.ApplicantScreen = exports.ApplicantListFilter = exports.ApplicantGridHeader = exports.ApplicantGrid = exports.ApplicantBadge = exports.AdminScreen = undefined;
 
 var _AdminScreen = __webpack_require__(48);
 
@@ -7525,6 +7529,10 @@ var _SolutionForm = __webpack_require__(136);
 
 var _SolutionForm2 = _interopRequireDefault(_SolutionForm);
 
+var _SettingsScreen = __webpack_require__(138);
+
+var _SettingsScreen2 = _interopRequireDefault(_SettingsScreen);
+
 var _SvgIcon = __webpack_require__(5);
 
 var _SvgIcon2 = _interopRequireDefault(_SvgIcon);
@@ -7549,15 +7557,15 @@ var _TruncatedList = __webpack_require__(14);
 
 var _TruncatedList2 = _interopRequireDefault(_TruncatedList);
 
-var _Typography = __webpack_require__(138);
+var _Typography = __webpack_require__(139);
 
 var _Typography2 = _interopRequireDefault(_Typography);
 
-var _VideoPlayer = __webpack_require__(139);
+var _VideoPlayer = __webpack_require__(140);
 
 var _VideoPlayer2 = _interopRequireDefault(_VideoPlayer);
 
-var _XIcon = __webpack_require__(140);
+var _XIcon = __webpack_require__(141);
 
 var _XIcon2 = _interopRequireDefault(_XIcon);
 
@@ -7603,6 +7611,7 @@ exports.SearchForm = _SearchForm2.default;
 exports.SelectBox = _SelectBox2.default;
 exports.SolutionForm = _SolutionForm2.default;
 exports.SvgIcon = _SvgIcon2.default;
+exports.SettingsScreen = _SettingsScreen2.default;
 exports.Tab = _Tab2.default;
 exports.Tabs = _Tabs2.default;
 exports.Text = _Text2.default;
@@ -19097,7 +19106,7 @@ var dimensions = {
   headerHeight: '86px',
   headingHeight: '60px',
   searchWidth: (_searchWidth = {}, _defineProperty(_searchWidth, _constants.DISPLAY_MODES.LIST, '530px'), _defineProperty(_searchWidth, _constants.DISPLAY_MODES.TABULAR, '1508px'), _searchWidth),
-  searchHeight: (_searchHeight = {}, _defineProperty(_searchHeight, _constants.DISPLAY_MODES.LIST, '410px'), _defineProperty(_searchHeight, _constants.DISPLAY_MODES.TABULAR, 'auto'), _searchHeight)
+  searchHeight: (_searchHeight = {}, _defineProperty(_searchHeight, _constants.DISPLAY_MODES.LIST, '420px'), _defineProperty(_searchHeight, _constants.DISPLAY_MODES.TABULAR, 'auto'), _searchHeight)
 };
 
 var cx = {
@@ -31318,6 +31327,112 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _react = __webpack_require__(0);
 
+var _react2 = _interopRequireDefault(_react);
+
+var _theme = __webpack_require__(2);
+
+var _theme2 = _interopRequireDefault(_theme);
+
+var _typo = __webpack_require__(4);
+
+var _typo2 = _interopRequireDefault(_typo);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var cmz = __webpack_require__(1);
+
+var cx = {
+  main: cmz.named('AutoUI_ui_SettingsScreen-13', /*cmz|*/'\n    height: calc(100vh - 86px)\n    position: relative\n    display: flex\n  ' /*|cmz*/),
+
+  navigation: cmz.named('AutoUI_ui_SettingsScreen-19', '\n    box-sizing: border-box\n    height: 100%\n    width: 315px\n    overflow: auto\n    background-color: ' + _theme2.default.baseBright + '\n    border-right: 2px solid ' + _theme2.default.lineSilver1 + '\n    padding: 65px 50px 65px 80px\n  '),
+
+  heading: cmz.named('AutoUI_ui_SettingsScreen-29', _typo2.default.sectionHeading, '\n    text-transform: uppercase\n    margin: 0 0 40px\n    color: ' + _theme2.default.typoHighlightOnDarkBackground + '\n  '),
+
+  menu: cmz.named('AutoUI_ui_SettingsScreen-35', _typo2.default.baseText, '\n    font-size: 16px\n    line-height: 1.6\n    text-transform: uppercase\n    list-style: none\n    padding: 0\n    margin: 0\n    color: ' + _theme2.default.typoParagraphOnDarkBackground + '\n  '),
+
+  menuItem: cmz.named('AutoUI_ui_SettingsScreen-45', '\n    & {\n      margin: 20px 0\n    }\n\n    & a {\n      text-decoration: none\n      color: ' + _theme2.default.typoParagraphOnDarkBackground + '\n    }\n\n    & a:hover,\n    & a.activeLink {\n      color: ' + _theme2.default.typoHighlightOnDarkBackground + '\n    }\n  '),
+
+  content: cmz.named('AutoUI_ui_SettingsScreen-61', /*cmz|*/'\n    box-sizing: border-box\n    height: 100%\n    flex: 1\n    overflow: auto\n    padding: 65px 100px\n  ' /*|cmz*/)
+};
+
+var SettingsScreen = function (_PureComponent) {
+  _inherits(SettingsScreen, _PureComponent);
+
+  function SettingsScreen() {
+    _classCallCheck(this, SettingsScreen);
+
+    return _possibleConstructorReturn(this, (SettingsScreen.__proto__ || Object.getPrototypeOf(SettingsScreen)).apply(this, arguments));
+  }
+
+  _createClass(SettingsScreen, [{
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          menu = _props.menu,
+          children = _props.children;
+
+      return _react2.default.createElement(
+        'div',
+        { className: cx.main },
+        _react2.default.createElement(
+          'div',
+          { className: cx.navigation },
+          _react2.default.createElement(
+            'h1',
+            { className: cx.heading },
+            'Settings'
+          ),
+          _react2.default.createElement(
+            'ul',
+            { className: cx.menu },
+            menu.map(function (item, i) {
+              return _react2.default.createElement(
+                'li',
+                { key: i, className: cx.menuItem },
+                item
+              );
+            })
+          )
+        ),
+        _react2.default.createElement(
+          'div',
+          { className: cx.content },
+          children
+        )
+      );
+    }
+  }]);
+
+  return SettingsScreen;
+}(_react.PureComponent);
+
+SettingsScreen.defaultProps = {
+  menu: [],
+  children: null
+};
+exports.default = SettingsScreen;
+
+/***/ }),
+/* 139 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = __webpack_require__(0);
+
 var _elem = __webpack_require__(3);
 
 var _elem2 = _interopRequireDefault(_elem);
@@ -31378,7 +31493,7 @@ var Typography = function (_PureComponent) {
 exports.default = Typography;
 
 /***/ }),
-/* 139 */
+/* 140 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -31509,7 +31624,7 @@ VideoPlayer.defaultProps = {
 exports.default = VideoPlayer;
 
 /***/ }),
-/* 140 */
+/* 141 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -31538,7 +31653,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var cmz = __webpack_require__(1);
 
 var Img = _elem2.default.img(cmz.named('AutoUI_ui_XIcon-11', /*cmz|*/'\n  width: 55px\n  margin: 0 0 56px 0\n' /*|cmz*/), {
-  src: __webpack_require__(141),
+  src: __webpack_require__(142),
   alt: 'X-Team Logo'
 });
 
@@ -31564,7 +31679,7 @@ var XIcon = function (_PureComponent) {
 exports.default = XIcon;
 
 /***/ }),
-/* 141 */
+/* 142 */
 /***/ (function(module, exports) {
 
 module.exports = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAH8AAACACAMAAAAVp0btAAAAPFBMVEVMaXFYU1IjISAuKyspJiYEBANeWFgDAwIYGBgqKChMSEdnYWBSTUw7NzZEQD84NDRAPDsBAQEAAAAcGhmojgR2AAAAEXRSTlMAQf/p9v41+wMFaiZUt4rHnuUwTmUAAARhSURBVGjexZvrdoIwEIRBQInYWvD937XhIkbIZWc2oue0/8J8Owlkk2yKIvEzxbXq7H/yZ4qyuvLNi7a4PgYewMrXw+lGA5hR/kIDWPmTbU4DTNFfehZglu9pgEW+JwEm8+fmFMAqzwEs0c/NT/ggdOTHJ9Rn7Alr9D3nwJs8DuBETzmwkZ8ASvkTNvIwwCjfu+0xB3byYBfsoscc8MhDDnjl5Q545QEHAvJSBwLyYgeC8jKAoLwQwDP0kC6IyIsAItFLHIjKCwCi0acdMMUtJp8ESESfciApnwAQyMcABPJRgKT5cQCR/Nj8cbVSZPRhAKF80AFh9CEAsXzAAXH0fgBA3gsARO8DgOQ9AKD8FgCU3wFA5vsAQPkdABj9Op+2Mz0svwA8f78PuL37HpmKar4CdDXR/pVRtG6uizSvnr1f0gDXGeBcEx1gB9AKcFIBGBxgmki9qwUYoCUANvO4OdiBXRqhA0Ad8GQxii54oADeJErhAAgQyOGOciCYQh4DEMlgjwCIJtA5AKqBz98/7kByAfVZBwRL6E86IFrBfw5AuIGgAzDBLrDzvWwHRwdQBBwANpA0AL8LQLXbgKrkO3g0QNOvAPV2/w7ZQOQdaLwOwBuohknp7G9oVoCucjZgK3D/VtEFza4L8O3jrA4Q0ed0gIpeA+A4MA5CLnpNF/RvXUDL53HgflYcwKkHYbv8FQc70L8ANPIZHND+JoCGAbhYAJNB365LGmoyrEql+bq5uOq+LW8K9fCn92amz05bmE71+neVJnob+k+t+fzx8udFvuG/v9a8uzb65kJPf3nkG3b+tc2zyJPpz9w8hzwF4DbXynMO/OWTZwB+HxnlUYDWyjc55TGA8TiiuQw55RGAseyozxs9Vj9wewz55aUAhjlNkcjLADLI98E3R1I/wKWbIvk0wIfl0/UD3Wfl4wAtmW8sz5TIxwAML1+K5cP1A3aldOfkT4h8yAE23QGjDznApjuEfMABasKn5L0AfxeV/L2Hmu+6QCn/04PN385fiynfGA6Lfnf+TKU7q4fm3uMjt1nP3w2X7ry6sOOO/+vbU57ZYHgNYeqzvdpPTvjuAG5Tp27BjyZ97LutvwEdeA2dHPKCc8dg9Oc6gzzogNO840pn9p9vACCDvLf+Tvgwt3mu6AGAN3qi8ClWfykAWIfes/CLqdsx9H7Vhr7FC+cS+XPy+L/c1N2AhYOp+uMogKc5WDiZXj910eP/0lN3AxSOStaPQYCAeUDhrGz9HAAI9p24cFh2gSAAEBk60sLpm3T/xAMQHbmywvGb/P5Jtz/+T9TdpAvnb8j9mw1A8uaEBYjX7WA3mDYAorqbSCaAX6DaHP+L6m4idTv4DTYHQHhzKFK3w1ygc47/a2ndjReAvUC4AAA3xwJ1O+wFyhkA2Xj2ACjub84AYN3Nrm5HcX91BLiXmrobnTxz/P8GoJVnjl+dpUwOecWp53fknRf3O/Lri/st+QXge/Lzi3uA/D8VOT3fioLq1AAAAABJRU5ErkJggg=="

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -31350,7 +31350,7 @@ var cmz = __webpack_require__(1);
 var cx = {
   main: cmz.named('AutoUI_ui_SettingsScreen-13', /*cmz|*/'\n    height: calc(100vh - 86px)\n    position: relative\n    display: flex\n  ' /*|cmz*/),
 
-  navigation: cmz.named('AutoUI_ui_SettingsScreen-19', '\n    box-sizing: border-box\n    height: 100%\n    width: 315px\n    overflow: auto\n    background-color: ' + _theme2.default.baseBright + '\n    border-right: 2px solid ' + _theme2.default.lineSilver1 + '\n    padding: 65px 50px 65px 80px\n  '),
+  navigation: cmz.named('AutoUI_ui_SettingsScreen-19', '\n    box-sizing: border-box\n    height: 100%\n    width: 315px\n    overflow: auto\n    background-color: ' + _theme2.default.baseBright + '\n    border-right: 2px solid ' + _theme2.default.lineSilver1 + '\n    padding: 65px 50px 65px 70px\n  '),
 
   heading: cmz.named('AutoUI_ui_SettingsScreen-29', _typo2.default.sectionHeading, '\n    text-transform: uppercase\n    margin: 0 0 40px\n    color: ' + _theme2.default.typoHighlightOnDarkBackground + '\n  '),
 

--- a/src/components/ui/ListsScreen.js
+++ b/src/components/ui/ListsScreen.js
@@ -28,7 +28,7 @@ const dimensions = {
     [DISPLAY_MODES.TABULAR]: '1508px'
   },
   searchHeight: {
-    [DISPLAY_MODES.LIST]: '410px',
+    [DISPLAY_MODES.LIST]: '420px',
     [DISPLAY_MODES.TABULAR]: 'auto'
   }
 }

--- a/src/components/ui/SettingsScreen.js
+++ b/src/components/ui/SettingsScreen.js
@@ -1,0 +1,103 @@
+// @flow
+
+import React, { PureComponent } from 'react'
+
+import theme from '../../styles/theme'
+import typo from '../../styles/typo'
+
+import type { Element } from 'react'
+
+const cmz = require('cmz')
+
+const cx = {
+  main: cmz(`
+    height: calc(100vh - 86px)
+    position: relative
+    display: flex
+  `),
+
+  navigation: cmz(`
+    box-sizing: border-box
+    height: 100%
+    width: 315px
+    overflow: auto
+    background-color: ${theme.baseBright}
+    border-right: 2px solid ${theme.lineSilver1}
+    padding: 65px 50px 65px 70px
+  `),
+
+  heading: cmz(typo.sectionHeading, `
+    text-transform: uppercase
+    margin: 0 0 40px
+    color: ${theme.typoHighlightOnDarkBackground}
+  `),
+
+  menu: cmz(typo.baseText, `
+    font-size: 16px
+    line-height: 1.6
+    text-transform: uppercase
+    list-style: none
+    padding: 0
+    margin: 0
+    color: ${theme.typoParagraphOnDarkBackground}
+  `),
+
+  menuItem: cmz(`
+    & {
+      margin: 20px 0
+    }
+
+    & a {
+      text-decoration: none
+      color: ${theme.typoParagraphOnDarkBackground}
+    }
+
+    & a:hover,
+    & a.activeLink {
+      color: ${theme.typoHighlightOnDarkBackground}
+    }
+  `),
+
+  content: cmz(`
+    box-sizing: border-box
+    height: 100%
+    flex: 1
+    overflow: auto
+    padding: 65px 100px
+  `),
+}
+
+type Props = {
+  menu: Array<*>,
+  children?: Element<*>
+}
+
+class SettingsScreen extends PureComponent<Props, void> {
+  static defaultProps = {
+    menu: [],
+    children: null
+  }
+
+  render () {
+    const { menu, children } = this.props
+    return (
+      <div className={cx.main}>
+        <div className={cx.navigation}>
+          <h1 className={cx.heading}>Settings</h1>
+          <ul className={cx.menu}>
+            {menu.map((item, i) => (
+              <li key={i} className={cx.menuItem}>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className={cx.content}>
+          {children}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default SettingsScreen

--- a/src/components/ui/SettingsScreen.js
+++ b/src/components/ui/SettingsScreen.js
@@ -23,40 +23,48 @@ const cx = {
     overflow: auto
     background-color: ${theme.baseBright}
     border-right: 2px solid ${theme.lineSilver1}
-    padding: 65px 50px 65px 70px
+    padding: 51px 50px 65px 70px
   `),
 
   heading: cmz(typo.sectionHeading, `
     text-transform: uppercase
+    font-size: 26px
+    font-weight: 800
     margin: 0 0 40px
     color: ${theme.typoHighlightOnDarkBackground}
   `),
 
-  menu: cmz(typo.baseText, `
-    font-size: 16px
-    line-height: 1.6
-    text-transform: uppercase
-    list-style: none
-    padding: 0
-    margin: 0
-    color: ${theme.typoParagraphOnDarkBackground}
-  `),
-
-  menuItem: cmz(`
-    & {
-      margin: 20px 0
-    }
-
-    & a {
-      text-decoration: none
+  menu: cmz(typo.baseText,
+    `
+      font-size: 16px
+      line-height: 1.6
+      text-transform: uppercase
+      list-style: none
+      padding: 0
+      margin: 0
       color: ${theme.typoParagraphOnDarkBackground}
-    }
+    `
+  ),
 
-    & a:hover,
-    & a.activeLink {
-      color: ${theme.typoHighlightOnDarkBackground}
-    }
-  `),
+  menuItem: cmz(typo.badgeHeading,
+    `
+      & {
+        margin: 20px 0
+      }
+
+      & a {
+        text-decoration: none
+        color: ${theme.typoParagraphOnDarkBackground}
+        font-size: 13px
+        letter-spacing: 1px
+      }
+
+      & a:hover,
+      & a.activeLink {
+        color: ${theme.typoHighlightOnDarkBackground}
+      }
+    `
+  ),
 
   content: cmz(`
     box-sizing: border-box
@@ -80,6 +88,7 @@ class SettingsScreen extends PureComponent<Props, void> {
 
   render () {
     const { menu, children } = this.props
+
     return (
       <div className={cx.main}>
         <div className={cx.navigation}>

--- a/src/components/ui/SettingsScreen.js
+++ b/src/components/ui/SettingsScreen.js
@@ -64,7 +64,7 @@ const cx = {
     flex: 1
     overflow: auto
     padding: 65px 100px
-  `),
+  `)
 }
 
 type Props = {

--- a/src/components/ui/SettingsScreen.md
+++ b/src/components/ui/SettingsScreen.md
@@ -1,0 +1,20 @@
+Complete:
+
+```js
+const content = Array(50).fill(<p>Anything goes in the content</p>);
+const menu = Array(50).fill(<a href="#">Menu link</a>);
+menu.push(<p>A strangely wide menu item just to make it more difficult and breakable, also this is not a link (<a href="#">this is a link</a>), this is just text...</p>);
+<div style={{ height: '500px' }}>
+  <SettingsScreen menu={menu}>
+    <div>
+      {content.map(each => each)}
+    </div>
+  </SettingsScreen>
+</div>
+```
+
+Missing props (does component explode?):
+
+```js
+<SettingsScreen />
+```

--- a/src/components/ui/SettingsScreen.md
+++ b/src/components/ui/SettingsScreen.md
@@ -1,10 +1,10 @@
-Complete:
+Basic usage:
 
 ```js
 const content = Array(50).fill(<p>Anything goes in the content</p>);
 const menu = Array(50).fill(<a href="#">Menu link</a>);
 menu.push(<p>A strangely wide menu item just to make it more difficult and breakable, also this is not a link (<a href="#">this is a link</a>), this is just text...</p>);
-<div style={{ height: '500px' }}>
+<div style={{ height: '500px', overflow: 'hidden' }}>
   <SettingsScreen menu={menu}>
     <div>
       {content.map(each => each)}

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ import RoadmapTimelineElement from './components/ui/RoadmapTimelineElement'
 import SearchForm from './components/ui/SearchForm'
 import SelectBox from './components/ui/SelectBox'
 import SolutionForm from './components/forms/SolutionForm'
+import SettingsScreen from './components/ui/SettingsScreen'
 import SvgIcon from './components/ui/SvgIcon'
 import Tab from './components/ui/Tabs/Tab'
 import Tabs from './components/ui/Tabs/Tabs'
@@ -88,6 +89,7 @@ export {
   SelectBox,
   SolutionForm,
   SvgIcon,
+  SettingsScreen,
   Tab,
   Tabs,
   Text,

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,8 @@ import RoadmapLevel from './components/ui/RoadmapLevel'
 import RoadmapTimelineElement from './components/ui/RoadmapTimelineElement'
 import SearchForm from './components/ui/SearchForm'
 import SelectBox from './components/ui/SelectBox'
-import SolutionForm from './components/forms/SolutionForm'
 import SettingsScreen from './components/ui/SettingsScreen'
+import SolutionForm from './components/forms/SolutionForm'
 import SvgIcon from './components/ui/SvgIcon'
 import Tab from './components/ui/Tabs/Tab'
 import Tabs from './components/ui/Tabs/Tabs'
@@ -87,9 +87,9 @@ export {
   RoadmapTimelineElement,
   SearchForm,
   SelectBox,
+  SettingsScreen,
   SolutionForm,
   SvgIcon,
-  SettingsScreen,
   Tab,
   Tabs,
   Text,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -38,7 +38,9 @@ const palette = {
   bombay: '#B2B6BC',
   lima: '#5fcf21',
   ripeLemon: '#f8e71c',
-  frenchGray: '#c2c1c5'
+  frenchGray: '#c2c1c5',
+  frenchGrayDarker: '#B8B7BC',
+  scarpaFlow: '#5A5665'
 }
 
 export default wrap({
@@ -56,7 +58,9 @@ export default wrap({
   typoHeading: palette.tuna,
   typoSubheading: palette.radicalRed,
   typoParagraph: palette.tuna,
+  typoParagraphOnDarkBackground: palette.frenchGrayDarker,
   typoHighlight: palette.haiti,
+  typoHighlightOnDarkBackground: palette.scarpaFlow,
   typoLabel: palette.bombay,
 
   sliderToggle: palette.bombay,


### PR DESCRIPTION
**Release Type:** *Non-Breaking Feature*

Fixes https://x-team-internal.atlassian.net/browse/XP-2232

## Description

This PR includes a new SettingsScreen component.

## Checklist

- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (initially it's mostly `[zube]: In Review`)
- [x] set `[zube]: In Review` label for respective issue as well
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run typecheck`)
- [x] my change requires a change to the component's documentation (`.snap`)
- [x] component's documentation (`.snap`) is changed or added accordingly
- [x] **manually tested the component** by running it in the browser and checked nothing is broken and operates as expected!

## Related PRs


branch | PR
------ | ------
`XP-2357-create-settings-route` | [Auto](https://github.com/x-team/auto/pull/1579)


## Screenshots

The demonstration in Styleguidist of this kind of component is usually quite broken, because have some pros that relates to window screen. The preview bellow is the final implementation in the app, along with PR https://github.com/x-team/auto/pull/1579:

![screen recording 2018-10-09 at 07 40 pm](https://user-images.githubusercontent.com/131859/46704098-e2626b80-cbff-11e8-9e8d-b13be472646b.gif)
