### PR TITLE
Update `babel-plugin-cmz-names` to fix Windows issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -837,9 +837,9 @@
       }
     },
     "babel-plugin-cmz-names": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-cmz-names/-/babel-plugin-cmz-names-1.4.0.tgz",
-      "integrity": "sha512-Wz1jLHIM2IyGOZj+Zj6vI6isnSVxZAf6M7SKnkpOykvIW5Rx/1rZhzTYJ3Y/Iu03g7sjTPF3FUKzq5tKpywavg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-cmz-names/-/babel-plugin-cmz-names-1.5.0.tgz",
+      "integrity": "sha512-A5PlS4/WsHTQ93u7fLnRNkgxpgj1sEV4i0mnwBNWKRvxyZCyIjl7qEy8e/ZFSpf5Y4ZDSGHtCdS5nqslY24CCw==",
       "dev": true
     },
     "babel-plugin-istanbul": {
@@ -4299,8 +4299,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
@@ -4902,8 +4902,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-cli": "^6.26.0",
     "babel-eslint": "8.0.3",
     "babel-loader": "^7.1.2",
-    "babel-plugin-cmz-names": "^1.4.0",
+    "babel-plugin-cmz-names": "^1.5.0",
     "babel-plugin-syntax-flow": "^6.18.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
Creating this just so that we don't forget.

Details of the resolved issue here:

https://github.com/joshwnj/babel-plugin-cmz-names/pull/1

Already tested successfully in my Windows environment with this repo.
