### PR TITLE
Include ability to persist keyword from input of Keywords on blur

### DIFF
--- a/.snapguidist/__snapshots__/Keywords-1.snap
+++ b/.snapguidist/__snapshots__/Keywords-1.snap
@@ -55,7 +55,7 @@ exports[`Keywords-1 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-15--value">
+      id="react-select-12--value">
       <div
         className="Select-value">
         <span
@@ -66,7 +66,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-0"
+          id="react-select-12--value-0"
           role="option">
           a
           <span
@@ -85,7 +85,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-1"
+          id="react-select-12--value-1"
           role="option">
           simple
           <span
@@ -104,7 +104,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-2"
+          id="react-select-12--value-2"
           role="option">
           string
           <span
@@ -123,7 +123,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-3"
+          id="react-select-12--value-3"
           role="option">
           separated
           <span
@@ -142,7 +142,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-4"
+          id="react-select-12--value-4"
           role="option">
           by
           <span
@@ -161,7 +161,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-5"
+          id="react-select-12--value-5"
           role="option">
           commas
           <span
@@ -180,7 +180,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-6"
+          id="react-select-12--value-6"
           role="option">
           with
           <span
@@ -199,7 +199,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-7"
+          id="react-select-12--value-7"
           role="option">
           operators
           <span
@@ -218,7 +218,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-8"
+          id="react-select-12--value-8"
           role="option">
           AND
           <span
@@ -237,7 +237,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-15--value-9"
+          id="react-select-12--value-9"
           role="option">
           OR
           <span
@@ -254,7 +254,7 @@ exports[`Keywords-1 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-15--value"
+          aria-activedescendant="react-select-12--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Keywords-1.snap
+++ b/.snapguidist/__snapshots__/Keywords-1.snap
@@ -55,7 +55,7 @@ exports[`Keywords-1 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-12--value">
+      id="react-select-52--value">
       <div
         className="Select-value">
         <span
@@ -66,7 +66,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-0"
+          id="react-select-52--value-0"
           role="option">
           a
           <span
@@ -85,7 +85,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-1"
+          id="react-select-52--value-1"
           role="option">
           simple
           <span
@@ -104,7 +104,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-2"
+          id="react-select-52--value-2"
           role="option">
           string
           <span
@@ -123,7 +123,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-3"
+          id="react-select-52--value-3"
           role="option">
           separated
           <span
@@ -142,7 +142,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-4"
+          id="react-select-52--value-4"
           role="option">
           by
           <span
@@ -161,7 +161,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-5"
+          id="react-select-52--value-5"
           role="option">
           commas
           <span
@@ -180,7 +180,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-6"
+          id="react-select-52--value-6"
           role="option">
           with
           <span
@@ -199,7 +199,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-7"
+          id="react-select-52--value-7"
           role="option">
           operators
           <span
@@ -218,7 +218,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-8"
+          id="react-select-52--value-8"
           role="option">
           AND
           <span
@@ -237,7 +237,7 @@ exports[`Keywords-1 1`] = `
         <span
           aria-selected="true"
           className="Select-value-label"
-          id="react-select-12--value-9"
+          id="react-select-52--value-9"
           role="option">
           OR
           <span
@@ -254,7 +254,7 @@ exports[`Keywords-1 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-12--value"
+          aria-activedescendant="react-select-52--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Keywords-3.snap
+++ b/.snapguidist/__snapshots__/Keywords-3.snap
@@ -5,7 +5,7 @@ exports[`Keywords-3 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-13--value">
+      id="react-select-53--value">
       <div
         className="Select-placeholder">
         Type keywords
@@ -18,7 +18,7 @@ exports[`Keywords-3 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-13--value"
+          aria-activedescendant="react-select-53--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Keywords-3.snap
+++ b/.snapguidist/__snapshots__/Keywords-3.snap
@@ -5,7 +5,7 @@ exports[`Keywords-3 1`] = `
     className="Select-control">
     <span
       className="Select-multi-value-wrapper"
-      id="react-select-16--value">
+      id="react-select-13--value">
       <div
         className="Select-placeholder">
         Type keywords
@@ -18,7 +18,7 @@ exports[`Keywords-3 1`] = `
           }
         }>
         <input
-          aria-activedescendant="react-select-16--value"
+          aria-activedescendant="react-select-13--value"
           aria-expanded="false"
           aria-haspopup="false"
           aria-owns=""

--- a/.snapguidist/__snapshots__/Note-3.snap
+++ b/.snapguidist/__snapshots__/Note-3.snap
@@ -21,7 +21,7 @@ exports[`Note-3 1`] = `
     </span>
     <div
       className="AutoUI_ui_Note-58 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      24 Oct 18
+      25 Oct 18
     </div>
     <div
       className="AutoUI_ui_Note-68">

--- a/.snapguidist/__snapshots__/Note-5.snap
+++ b/.snapguidist/__snapshots__/Note-5.snap
@@ -9,7 +9,7 @@ exports[`Note-5 1`] = `
     </span>
     <div
       className="AutoUI_ui_Note-58 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      24 Oct 18
+      25 Oct 18
     </div>
     <div
       className="AutoUI_ui_Note-68">

--- a/.snapguidist/__snapshots__/Note-9.snap
+++ b/.snapguidist/__snapshots__/Note-9.snap
@@ -21,7 +21,7 @@ exports[`Note-9 1`] = `
     </span>
     <div
       className="AutoUI_ui_Note-58 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40">
-      24 Oct 18
+      25 Oct 18
       , in Interview Notes
     </div>
     <div

--- a/.snapguidist/__snapshots__/SearchForm-1.snap
+++ b/.snapguidist/__snapshots__/SearchForm-1.snap
@@ -715,7 +715,7 @@ exports[`SearchForm-1 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-14--value">
+          id="react-select-56--value">
           <div
             className="Select-value">
             <span
@@ -726,7 +726,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-0"
+              id="react-select-56--value-0"
               role="option">
               a keyword
               <span
@@ -745,7 +745,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-1"
+              id="react-select-56--value-1"
               role="option">
               OR
               <span
@@ -764,7 +764,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-2"
+              id="react-select-56--value-2"
               role="option">
               two
               <span
@@ -783,7 +783,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-3"
+              id="react-select-56--value-3"
               role="option">
               AND
               <span
@@ -802,7 +802,7 @@ exports[`SearchForm-1 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-14--value-4"
+              id="react-select-56--value-4"
               role="option">
               much more
               <span
@@ -819,7 +819,7 @@ exports[`SearchForm-1 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-14--value"
+              aria-activedescendant="react-select-56--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-3.snap
+++ b/.snapguidist/__snapshots__/SearchForm-3.snap
@@ -618,7 +618,7 @@ exports[`SearchForm-3 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-15--value">
+          id="react-select-55--value">
           <div
             className="Select-value">
             <span
@@ -629,7 +629,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-15--value-0"
+              id="react-select-55--value-0"
               role="option">
               a keyword
               <span
@@ -648,7 +648,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-15--value-1"
+              id="react-select-55--value-1"
               role="option">
               OR
               <span
@@ -667,7 +667,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-15--value-2"
+              id="react-select-55--value-2"
               role="option">
               two
               <span
@@ -686,7 +686,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-15--value-3"
+              id="react-select-55--value-3"
               role="option">
               AND
               <span
@@ -705,7 +705,7 @@ exports[`SearchForm-3 1`] = `
             <span
               aria-selected="true"
               className="Select-value-label"
-              id="react-select-15--value-4"
+              id="react-select-55--value-4"
               role="option">
               much more
               <span
@@ -722,7 +722,7 @@ exports[`SearchForm-3 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-15--value"
+              aria-activedescendant="react-select-55--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/.snapguidist/__snapshots__/SearchForm-5.snap
+++ b/.snapguidist/__snapshots__/SearchForm-5.snap
@@ -434,7 +434,7 @@ exports[`SearchForm-5 1`] = `
         className="Select-control">
         <span
           className="Select-multi-value-wrapper"
-          id="react-select-16--value">
+          id="react-select-54--value">
           <div
             className="Select-placeholder">
             Type keywords
@@ -447,7 +447,7 @@ exports[`SearchForm-5 1`] = `
               }
             }>
             <input
-              aria-activedescendant="react-select-16--value"
+              aria-activedescendant="react-select-54--value"
               aria-expanded="false"
               aria-haspopup="false"
               aria-owns=""

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -6292,14 +6292,18 @@ var Keywords = function (_Component) {
     }
 
     return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Keywords.__proto__ || Object.getPrototypeOf(Keywords)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
-      values: _this.props.values
+      values: _this.props.values,
+      input: ''
     }, _this.uppercaseOpperators = function (value) {
       var upperCasedLabel = value.toUpperCase();
       return ['AND', 'OR'].includes(upperCasedLabel) ? upperCasedLabel : value;
     }, _this.handleChange = function (values) {
+      var input = _this.state.input;
+
       var newValues = values.map(function (keyword) {
         return _this.uppercaseOpperators(keyword.label);
       }).join(',');
+
       _this.setState(function (prevState) {
         return { values: newValues };
       }, function () {
@@ -6307,6 +6311,9 @@ var Keywords = function (_Component) {
 
         onChange && onChange(newValues);
       });
+    }, _this.handleInputChange = function (value) {
+      _this.setState({ input: value });
+      return value;
     }, _this.handleInputKeyDown = function (event) {
       // ENTER
       if (event && event.keyCode === 13) {
@@ -6314,6 +6321,20 @@ var Keywords = function (_Component) {
 
         _onSubmit && _onSubmit();
       }
+    }, _this.handleBlur = function () {
+      var _this$state = _this.state,
+          values = _this$state.values,
+          input = _this$state.input;
+
+      var newValues = [values, input].filter(Boolean).join(',');
+      _this.setState({
+        values: newValues,
+        input: ''
+      }, function () {
+        var onChange = _this.props.onChange;
+
+        onChange && onChange(newValues);
+      });
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 
@@ -6348,7 +6369,10 @@ var Keywords = function (_Component) {
         multi: true,
         clearable: true,
         onChange: this.handleChange,
-        onInputKeyDown: this.handleInputKeyDown
+        onInputChange: this.handleInputChange,
+        onInputKeyDown: this.handleInputKeyDown,
+        onSelectResetsInput: false,
+        onBlur: this.handleBlur
       });
     }
   }]);

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -6293,12 +6293,12 @@ var Keywords = function (_Component) {
 
     return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Keywords.__proto__ || Object.getPrototypeOf(Keywords)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       values: _this.props.values
-    }, _this.uppercaseOpperators = function (value) {
+    }, _this.uppercaseOperators = function (value) {
       var upperCasedLabel = value.toUpperCase();
       return ['AND', 'OR'].includes(upperCasedLabel) ? upperCasedLabel : value;
     }, _this.handleChange = function (values) {
       var newValues = values.map(function (keyword) {
-        return _this.uppercaseOpperators(keyword.label);
+        return _this.uppercaseOperators(keyword.label);
       }).join(',');
 
       _this.setState(function (prevState) {
@@ -6320,6 +6320,7 @@ var Keywords = function (_Component) {
       var input = event.target.value;
 
       var newValues = [values, input].filter(Boolean).join(',');
+
       _this.setState({ values: newValues }, function () {
         var onChange = _this.props.onChange;
 
@@ -6347,7 +6348,7 @@ var Keywords = function (_Component) {
       var keywords = this.state.values.split(',').map(String).filter(Boolean).map(function (keyword, i) {
         return {
           value: i,
-          label: _this2.uppercaseOpperators(keyword)
+          label: _this2.uppercaseOperators(keyword)
         };
       }) || [];
 

--- a/lib/auto-ui.js
+++ b/lib/auto-ui.js
@@ -6292,14 +6292,11 @@ var Keywords = function (_Component) {
     }
 
     return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Keywords.__proto__ || Object.getPrototypeOf(Keywords)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
-      values: _this.props.values,
-      input: ''
+      values: _this.props.values
     }, _this.uppercaseOpperators = function (value) {
       var upperCasedLabel = value.toUpperCase();
       return ['AND', 'OR'].includes(upperCasedLabel) ? upperCasedLabel : value;
     }, _this.handleChange = function (values) {
-      var input = _this.state.input;
-
       var newValues = values.map(function (keyword) {
         return _this.uppercaseOpperators(keyword.label);
       }).join(',');
@@ -6311,9 +6308,6 @@ var Keywords = function (_Component) {
 
         onChange && onChange(newValues);
       });
-    }, _this.handleInputChange = function (value) {
-      _this.setState({ input: value });
-      return value;
     }, _this.handleInputKeyDown = function (event) {
       // ENTER
       if (event && event.keyCode === 13) {
@@ -6321,16 +6315,12 @@ var Keywords = function (_Component) {
 
         _onSubmit && _onSubmit();
       }
-    }, _this.handleBlur = function () {
-      var _this$state = _this.state,
-          values = _this$state.values,
-          input = _this$state.input;
+    }, _this.handleBlur = function (event) {
+      var values = _this.state.values;
+      var input = event.target.value;
 
       var newValues = [values, input].filter(Boolean).join(',');
-      _this.setState({
-        values: newValues,
-        input: ''
-      }, function () {
+      _this.setState({ values: newValues }, function () {
         var onChange = _this.props.onChange;
 
         onChange && onChange(newValues);
@@ -6369,9 +6359,7 @@ var Keywords = function (_Component) {
         multi: true,
         clearable: true,
         onChange: this.handleChange,
-        onInputChange: this.handleInputChange,
         onInputKeyDown: this.handleInputKeyDown,
-        onSelectResetsInput: false,
         onBlur: this.handleBlur
       });
     }

--- a/src/components/ui/Keywords.js
+++ b/src/components/ui/Keywords.js
@@ -107,14 +107,14 @@ class Keywords extends Component<Props, State> {
     }
   }
 
-  uppercaseOpperators = (value: string) => {
+  uppercaseOperators = (value: string) => {
     const upperCasedLabel = value.toUpperCase()
     return ['AND', 'OR'].includes(upperCasedLabel) ? upperCasedLabel : value
   }
 
   handleChange = (values: Array<*>) => {
     const newValues = values
-      .map(keyword => this.uppercaseOpperators(keyword.label))
+      .map(keyword => this.uppercaseOperators(keyword.label))
       .join(',')
 
     this.setState(prevState => ({ values: newValues }), () => {
@@ -135,6 +135,7 @@ class Keywords extends Component<Props, State> {
     const { values } = this.state
     const { target: { value: input } } = event
     const newValues = [values, input].filter(Boolean).join(',')
+
     this.setState({ values: newValues }, () => {
       const { onChange } = this.props
       onChange && onChange(newValues)
@@ -148,7 +149,7 @@ class Keywords extends Component<Props, State> {
       .filter(Boolean)
       .map((keyword, i) => ({
         value: i,
-        label: this.uppercaseOpperators(keyword)
+        label: this.uppercaseOperators(keyword)
       })) || []
 
     return (

--- a/src/components/ui/Keywords.js
+++ b/src/components/ui/Keywords.js
@@ -86,8 +86,7 @@ type Props = {
 }
 
 type State = {
-  values: string,
-  input: string
+  values: string
 }
 
 class Keywords extends Component<Props, State> {
@@ -97,8 +96,7 @@ class Keywords extends Component<Props, State> {
   }
 
   state: State = {
-    values: this.props.values,
-    input: ''
+    values: this.props.values
   }
 
   componentDidUpdate (prevProps: Props) {
@@ -115,7 +113,6 @@ class Keywords extends Component<Props, State> {
   }
 
   handleChange = (values: Array<*>) => {
-    const { input } = this.state
     const newValues = values
       .map(keyword => this.uppercaseOpperators(keyword.label))
       .join(',')
@@ -126,11 +123,6 @@ class Keywords extends Component<Props, State> {
     })
   }
 
-  handleInputChange = (value: string) => {
-    this.setState({ input: value })
-    return value
-  }
-
   handleInputKeyDown = (event: SyntheticInputEvent<>) => {
     // ENTER
     if (event && event.keyCode === 13) {
@@ -139,13 +131,11 @@ class Keywords extends Component<Props, State> {
     }
   }
 
-  handleBlur = () => {
-    const { values, input } = this.state
+  handleBlur = (event: SyntheticInputEvent<>) => {
+    const { values } = this.state
+    const { target: { value: input } } = event
     const newValues = [values, input].filter(Boolean).join(',')
-    this.setState({
-      values: newValues,
-      input: ''
-    }, () => {
+    this.setState({ values: newValues }, () => {
       const { onChange } = this.props
       onChange && onChange(newValues)
     })
@@ -170,9 +160,7 @@ class Keywords extends Component<Props, State> {
         multi
         clearable
         onChange={this.handleChange}
-        onInputChange={this.handleInputChange}
         onInputKeyDown={this.handleInputKeyDown}
-        onSelectResetsInput={false}
         onBlur={this.handleBlur}
       />
     )

--- a/src/components/ui/Keywords.js
+++ b/src/components/ui/Keywords.js
@@ -86,7 +86,8 @@ type Props = {
 }
 
 type State = {
-  values: string
+  values: string,
+  input: string
 }
 
 class Keywords extends Component<Props, State> {
@@ -96,7 +97,8 @@ class Keywords extends Component<Props, State> {
   }
 
   state: State = {
-    values: this.props.values
+    values: this.props.values,
+    input: ''
   }
 
   componentDidUpdate (prevProps: Props) {
@@ -113,13 +115,20 @@ class Keywords extends Component<Props, State> {
   }
 
   handleChange = (values: Array<*>) => {
+    const { input } = this.state
     const newValues = values
       .map(keyword => this.uppercaseOpperators(keyword.label))
       .join(',')
+
     this.setState(prevState => ({ values: newValues }), () => {
       const { onChange } = this.props
       onChange && onChange(newValues)
     })
+  }
+
+  handleInputChange = (value: string) => {
+    this.setState({ input: value })
+    return value
   }
 
   handleInputKeyDown = (event: SyntheticInputEvent<>) => {
@@ -128,6 +137,18 @@ class Keywords extends Component<Props, State> {
       const { onSubmit } = this.props
       onSubmit && onSubmit()
     }
+  }
+
+  handleBlur = () => {
+    const { values, input } = this.state
+    const newValues = [values, input].filter(Boolean).join(',')
+    this.setState({
+      values: newValues,
+      input: ''
+    }, () => {
+      const { onChange } = this.props
+      onChange && onChange(newValues)
+    })
   }
 
   render () {
@@ -149,7 +170,10 @@ class Keywords extends Component<Props, State> {
         multi
         clearable
         onChange={this.handleChange}
+        onInputChange={this.handleInputChange}
         onInputKeyDown={this.handleInputKeyDown}
+        onSelectResetsInput={false}
+        onBlur={this.handleBlur}
       />
     )
   }


### PR DESCRIPTION

**Release Type:** *bug fix*
Fixes https://x-team-internal.atlassian.net/browse/XP-2181

## Description

Include ability to persist keyword from input of Keywords on blur

## Checklist


- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (`In Review` or `In Progress` depending on its status)
- [x] move respective Jira issue to the `IN REVIEW` column
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run typecheck`)
- [x] if any snapshots have been changed, verify that component still works and looks as expected and update the changed snapshot
- [x] **manually tested the component** by running it in the browser and checked nothing is broken and operates as expected!

## Steps to Test or Reproduce

1. While typing new string into keywords field, without keypressing tab or enter, leave the field or click on `show` button, the new string should be added as a keyword tag and in case of `show` button is pressed the search with the new keyword should be performed.

## Impacted Areas in Application

`Keywords` component.

## Screenshots

![screen recording 2018-10-25 at 05 12 pm](https://user-images.githubusercontent.com/131859/47527563-2c428700-d879-11e8-9204-a30a528da653.gif)

