### PR TITLE
Add source maps to built lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack --config webpack.standalone.js",
+    "watch": "npm run build -- --watch",
     "flow": "flow check src",
     "lint": "standard \"src/**/*.js\" | snazzy",
     "lint-fix": "standard \"src/**/*.js\" --fix | snazzy",

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -4,6 +4,7 @@ const base = require('./webpack.config')
 
 module.exports = {
   entry: './src/index.js',
+  devtool: 'source-maps',
   output: {
     path: path.resolve('./lib'),
     filename: 'auto-ui.js',


### PR DESCRIPTION
**Release Type:** *Dev Improvements*

## Description

While working and investigating https://github.com/x-team/auto-ui/pull/270, it was getting difficult to nail down the root cause of the bug because it was related to an integration between an `auto` screen and an `auto-ui` component.

I decided to add source maps so that it was possible to debug `auto-ui` code from the running application in `auto`. 

I also added a `watch` npm script to streamline the development flow even more. Using `npm link`, the source maps and watch mode, doing a change in `auto-ui` becomes immediately available and debuggable in `auto` (after compilation finishes, of course).

I think this will bring a boost to our productivity moving forward! 

Hope you guys feel the same way.

**Please review the necessary changes in Auto for this to work: https://github.com/x-team/auto/pull/1632**